### PR TITLE
Issue #4 - DOMConv_UnitTesting_LDDDOMParser_Cart_Geom_abort

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -181,8 +181,8 @@ public class DMDocument extends Object {
 	static ArrayList <LDDDOMParser> LDDDOMModelArr;
 	
 	// Schemas, Stewards and Namespaces (SchemaFileDefn)
-	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc
 	static TreeMap <String, SchemaFileDefn> masterAllSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();	// all namespaces in config.properties file.
+	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
 	static ArrayList <SchemaFileDefn> LDDSchemaFileSortArr;
 	
 	// Master Schemas, Stewards and Namespaces (SchemaFileDefn)
@@ -457,9 +457,8 @@ public class DMDocument extends Object {
 		// set up the System Build version
 		XMLSchemaLabelBuildNum = pds4BuildId;
 		
-	    // intialize the masterSchemaFileSortMap 
+	    // intialize the masterAllSchemaFileSortMap -  all namespaces in config.properties file
 		// set up the Master Schema Information for both normal and LDD processing (dirpath, namespaces, etc)
-//		masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();
 		setupNameSpaceInfoAll(props);
 		
 		// output the context info
@@ -838,10 +837,13 @@ public class DMDocument extends Object {
         		String isMasterKey = SCHEMA_LITERAL+nameSpaceId + ".isMaster";
         	    String value = prop.getProperty(isMasterKey);
         		if (value != null){
-        			if (value.equals("true"))
-        			   lSchemaFileDefn.isMaster = true;
-        			else
+        			if (value.equals("true")) {
+          			   lSchemaFileDefn.isMaster = true;
+         			   lSchemaFileDefn.isLDD = false;
+        			} else {
         				lSchemaFileDefn.isMaster = false;
+        				lSchemaFileDefn.isLDD = true;
+        			}
         		} else{
         			System.out.println("Missing schema config item: "+ isMasterKey);
         		}
@@ -894,7 +896,7 @@ public class DMDocument extends Object {
         		} else{
         			System.out.println("Missing schema config item: "+ stewardArrKey);
         		}
-        		lSchemaFileDefn.setVersionIds();
+//        		lSchemaFileDefn.setVersionIds();
         		
           		String commentKey = SCHEMA_LITERAL+nameSpaceId + ".comment";
         	    value = prop.getProperty(commentKey);
@@ -943,47 +945,53 @@ public class DMDocument extends Object {
         		if (value != null){        		
             			   lSchemaFileDefn.regAuthId = value;
         		}
-        		
-        		masterAllSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
 
-/*        		System.out.println("\ndebug setupNameSpaceInfoAll lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
-        		System.out.println("                            lSchemaFileDefn.lddName:" + lSchemaFileDefn.lddName);
-        		System.out.println("                            lSchemaFileDefn.versionId:" + lSchemaFileDefn.versionId);
-        		System.out.println("                            lSchemaFileDefn.labelVersionId:" + lSchemaFileDefn.labelVersionId);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNCLC:" + lSchemaFileDefn.nameSpaceIdNCLC);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNCUC:" + lSchemaFileDefn.nameSpaceIdNCUC);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceId:" + lSchemaFileDefn.nameSpaceId);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceURL:" + lSchemaFileDefn.nameSpaceURL);
-        		System.out.println("                            lSchemaFileDefn.nameSpaceURLs:" + lSchemaFileDefn.nameSpaceURLs);
-        		System.out.println("                            lSchemaFileDefn.modelShortName:" + lSchemaFileDefn.modelShortName);
-        		System.out.println("                            lSchemaFileDefn.regAuthId:" + lSchemaFileDefn.regAuthId);
-        		System.out.println("                            lSchemaFileDefn.governanceLevel:" + lSchemaFileDefn.governanceLevel);
-        		System.out.println("                            lSchemaFileDefn.isMaster:" + lSchemaFileDefn.isMaster);
-        		System.out.println("                            lSchemaFileDefn.isLDD:" + lSchemaFileDefn.isLDD);
-        		System.out.println("                            lSchemaFileDefn.isDiscipline:" + lSchemaFileDefn.isDiscipline);
-        		System.out.println("                            lSchemaFileDefn.isMission:" + lSchemaFileDefn.isMission);
-*/        		
+        		masterAllSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
         		
-        		if (!DMDocument.LDDToolFlag) {		// IMTool run
-        			masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
-            		if (lSchemaFileDefn.isMaster) {
-// 7777 isActive is set here temporarily until DOM is used; isActive is set above for all IngestLDD
-            			lSchemaFileDefn.isActive = true; 
-              		   masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
-              		   masterPDSSchemaFileDefn = lSchemaFileDefn;
-              		   masterNameSpaceIdNCLC = lSchemaFileDefn.nameSpaceIdNCLC;
-            		}
-         		} else {							// LDDTool run
-         			if (lSchemaFileDefn.isMaster) {
-               		   masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
-               		   masterPDSSchemaFileDefn = lSchemaFileDefn;
-               		   masterNameSpaceIdNCLC = lSchemaFileDefn.nameSpaceIdNCLC;
-           			   masterSchemaFileSortMap.put(masterLDDSchemaFileDefn.identifier, masterLDDSchemaFileDefn);
-         			}
-         		}
+/*				if (DMDocument.debugFlag) {
+	        		System.out.println("\ndebug setupNameSpaceInfoAll lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
+	        		System.out.println("                            lSchemaFileDefn.lddName:" + lSchemaFileDefn.lddName);
+	        		System.out.println("                            lSchemaFileDefn.versionId:" + lSchemaFileDefn.versionId);
+	        		System.out.println("                            lSchemaFileDefn.labelVersionId:" + lSchemaFileDefn.labelVersionId);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNCLC:" + lSchemaFileDefn.nameSpaceIdNCLC);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceIdNCUC:" + lSchemaFileDefn.nameSpaceIdNCUC);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceId:" + lSchemaFileDefn.nameSpaceId);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceURL:" + lSchemaFileDefn.nameSpaceURL);
+	        		System.out.println("                            lSchemaFileDefn.nameSpaceURLs:" + lSchemaFileDefn.nameSpaceURLs);
+	        		System.out.println("                            lSchemaFileDefn.modelShortName:" + lSchemaFileDefn.modelShortName);
+	        		System.out.println("                            lSchemaFileDefn.regAuthId:" + lSchemaFileDefn.regAuthId);
+	        		System.out.println("                            lSchemaFileDefn.governanceLevel:" + lSchemaFileDefn.governanceLevel);
+	        		System.out.println("                            lSchemaFileDefn.isMaster:" + lSchemaFileDefn.isMaster);
+	        		System.out.println("                            lSchemaFileDefn.isLDD:" + lSchemaFileDefn.isLDD);
+	        		System.out.println("                            lSchemaFileDefn.isDiscipline:" + lSchemaFileDefn.isDiscipline);
+	        		System.out.println("                            lSchemaFileDefn.isMission:" + lSchemaFileDefn.isMission);
+				} */
+        		
+     			if (lSchemaFileDefn.isMaster) {
+//           		   System.out.println("debug setupNameSpaceInfoAll - set masterPDSSchemaFileDefn - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
+           		   masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
+          		   masterPDSSchemaFileDefn = lSchemaFileDefn;
+           		   masterNameSpaceIdNCLC = lSchemaFileDefn.nameSpaceIdNCLC;
+           		   lSchemaFileDefn.isActive = true; // 7777 isActive is set here temporarily until DOM is used; isActive is set above for all IngestLDD
+     			}
         	}
           }
+        
+        	// set set VersionIds		
+    		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterAllSchemaFileSortMap.values());
+    		ArrayList <String> lNamespaceIdArr = new ArrayList <String> ();
+    		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
+    			SchemaFileDefn lSchemaFileDefn2 = (SchemaFileDefn) i.next();
+    			lNamespaceIdArr.add(lSchemaFileDefn2.identifier);
+    			lSchemaFileDefn2.setVersionIds();
+    		}
+    		System.out.println(">>info    - Configured NameSpaceIds:" + lNamespaceIdArr);
+    		
+    		// update to masterSchemaFileSortMap to process and write the target LDD
+    		if (DMDocument.LDDToolFlag) {	
+ 				masterSchemaFileSortMap.put(masterLDDSchemaFileDefn.identifier, masterLDDSchemaFileDefn);
+    		}
         }
 
 /**********************************************************************************************************

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -302,7 +302,7 @@ public class GetDOMModel extends Object {
 		DMDocument.masterDOMInfoModel.getSubClasses ();	
 	
 		// 016 - set the attribute isUsedInClass flag				
-		DMDocument.masterDOMInfoModel.setMasterAttrisUsedInClassFlag ();	
+		DMDocument.masterDOMInfoModel.setMasterAttrisUsedInClassFlag ();
 		
 		// 017 - overwrite master attributes from the 11179 DD
 		//     - either import from JSON 11179 file or overwrite from 11179 dictionary
@@ -489,7 +489,7 @@ public class GetDOMModel extends Object {
 		System.out.println("\n>>info    - Master Data Type Sizes     - DOMInfoModel.masterDOMDataTypeMap.size():" + DOMInfoModel.masterDOMDataTypeMap.size());
 		System.out.println(">>info                                 - DOMInfoModel.masterDOMDataTypeTitleMap.size():" + DOMInfoModel.masterDOMDataTypeTitleMap.size());
 		System.out.println(">>info                                 - DOMInfoModel.masterDOMDataTypeArr.size():" + DOMInfoModel.masterDOMDataTypeArr.size());
-		System.out.println("\n>>info    - Master Unit Sizes           - DOMInfoModel.masterDOMUnitMap.size():" + DOMInfoModel.masterDOMUnitMap.size());
+		System.out.println("\n>>info    - Master Unit Sizes          - DOMInfoModel.masterDOMUnitMap.size():" + DOMInfoModel.masterDOMUnitMap.size());
 		System.out.println(">>info                                 - DOMInfoModel.masterDOMUnitTitleMap.size():" + DOMInfoModel.masterDOMUnitTitleMap.size());
 		System.out.println(">>info                                 - DOMInfoModel.masterDOMUnitArr.size():" + DOMInfoModel.masterDOMUnitArr.size());
 		System.out.println(" ");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -212,7 +212,7 @@ class WriteDOMSchematron extends Object {
 			// namespaces required: all other LDD discipline levels referenced; no mission level allowed
 			for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 				String lNameSpaceIdNC = (String) i.next();
-				String lVersionNSId = (DMDocument.masterSchemaFileSortMap.get(lNameSpaceIdNC)).ns_version_id;
+				String lVersionNSId = (DMDocument.masterAllSchemaFileSortMap.get(lNameSpaceIdNC)).ns_version_id;
 				if (lVersionNSId == null) lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
 				prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + lNameSpaceIdNC + "/v" + lVersionNSId + "\" prefix=\"" + lNameSpaceIdNC + "\"/>");
 			}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -276,7 +276,7 @@ class XML4LabelSchemaDOM extends Object {
 			if (DMDocument.LDDToolFlag) {
 				for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 					String lNameSpaceIdNC = (String) i.next();
-					String lVersionNSId = (DMDocument.masterSchemaFileSortMap.get(lNameSpaceIdNC)).ns_version_id;
+					String lVersionNSId = (DMDocument.masterAllSchemaFileSortMap.get(lNameSpaceIdNC)).ns_version_id;
 					if (lVersionNSId == null) lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
 					prXML.println("    xmlns:" + lNameSpaceIdNC + "=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceURL + lNameSpaceIdNC + "/v" + lVersionNSId + "\"");
 				}

--- a/model-ontology/src/ontology/Data/config.properties
+++ b/model-ontology/src/ontology/Data/config.properties
@@ -173,6 +173,19 @@ lSchemaFileDefn.cart.modelShortName=PDS4
 lSchemaFileDefn.cart.regAuthId=0001_NASA_PDS_1
 lSchemaFileDefn.cart.comment=Contains classes and attributes used to describe cartographic products. This information is largely adapted from the FGDC "Content Standard for Digital Geospatial Metadata", with extensions (changes/additions) to satisfy planetary requirements.
 
+lSchemaFileDefn.img_surface.identifier=img_surface
+lSchemaFileDefn.img_surface.versionId=1.1.0.0
+lSchemaFileDefn.img_surface.labelVersionId=1.18
+lSchemaFileDefn.img_surface.isMaster=false
+lSchemaFileDefn.img_surface.isDiscipline=true
+lSchemaFileDefn.img_surface.stewardArr=img
+lSchemaFileDefn.img_surface.nameSpaceURL=http://pds.nasa.gov/pds4/
+lSchemaFileDefn.img_surface.nameSpaceURLs=https://pds.nasa.gov/pds4/
+lSchemaFileDefn.img_surface.urnPrefix=urn:nasa:pds:
+lSchemaFileDefn.img_surface.modelShortName=PDS4
+lSchemaFileDefn.img_surface.regAuthId=0001_NASA_PDS_1
+lSchemaFileDefn.img_surface.comment=Attributes specific to imaging instruments on surface missions.
+
 lSchemaFileDefn.darts.identifier=darts
 lSchemaFileDefn.darts.versionId=1.12.0.0
 lSchemaFileDefn.darts.labelVersionId=1.18


### PR DESCRIPTION
Problem: Input of two or more LDDs to LDDTool (an LDD stack) results in null pointer exception.
Analysis: LDDTool tried to find LDD nameSpaceID for "Import" statements in configured PDS4 nameSpaceID array.
Solution: Use masterAllSchemaFileSortMap instead of masterSchemaFileSortMap. The latter includes only those nameSpaces to be written to XML Schema file.