### PR TITLE
Issue-#7--DOMConv_UnitTesting_PINS_Test_classOrder

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -492,19 +492,21 @@ public class DMDocument extends Object {
 		setObjectDeprecatedFlag();
 		
 		// get the 11179 Attribute Dictionary - .pins file
-		ProtPins11179DD protPins11179DD  = new ProtPins11179DD ();
-		protPins11179DD.getProtPins11179DD(DMDocument.registrationAuthorityIdentifierValue, DMDocument.dataDirPath + "dd11179.pins");
+//		ProtPins11179DD protPins11179DD  = new ProtPins11179DD ();
+//		protPins11179DD.getProtPins11179DD(DMDocument.registrationAuthorityIdentifierValue, DMDocument.dataDirPath + "dd11179.pins");
+		ProtPinsDOM11179DD lProtPinsDOM11179DD  = new ProtPinsDOM11179DD ();
+		lProtPinsDOM11179DD.getProtPins11179DD(DMDocument.registrationAuthorityIdentifierValue, DMDocument.dataDirPath + "dd11179.pins");
 		
 // 999
 		// use the following for MOF and DOM testing.
 		// get the models
-		GetModels lGetModels = new GetModels();
-		lGetModels.getModels (PDSOptionalFlag, docFileName + ".pins");
+//		GetModels lGetModels = new GetModels();
+//		lGetModels.getModels (PDSOptionalFlag, docFileName + ".pins");
 		
 //		// use the following for DOM only testing		
 		// get the models
-//		GetDOMModelDoc lGetDOMModelDoc = new GetDOMModelDoc();
-//		lGetDOMModelDoc.getModels (PDSOptionalFlag, docFileName + ".pins");
+		GetDOMModelDoc lGetDOMModelDoc = new GetDOMModelDoc();
+		lGetDOMModelDoc.getModels (PDSOptionalFlag, docFileName + ".pins");
 		
 		// get the DOM Model
 		if (exportDOMFlag) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -103,6 +103,9 @@ public abstract class DOMInfoModel extends Object {
 	static TreeMap <String, DOMUnit> masterDOMUnitMap = new TreeMap <String, DOMUnit> ();
 	static TreeMap <String, DOMUnit> masterDOMUnitTitleMap = new TreeMap <String, DOMUnit> ();
 	
+	// global 11179 data dictionary
+	static TreeMap <String, InstDefn> master11179DataDict;
+	
 	// global UseCases
 	static ArrayList <DOMUseCase> masterDOMUseCaseArr = new ArrayList <DOMUseCase> ();
 	static TreeMap <String, DOMUseCase> masterDOMUseCaseMap = new TreeMap <String, DOMUseCase> ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -42,7 +42,7 @@ class ISO11179DOMMDR extends Object {
 		valueChangeMap = new TreeMap <String, String> ();
 				
 		// set up permissible value / value meaning map; need identifier from map
-		ArrayList <InstDefn> lMaster11179DataDictArr = new ArrayList <InstDefn> (InfoModel.master11179DataDict.values());
+		ArrayList <InstDefn> lMaster11179DataDictArr = new ArrayList <InstDefn> (DOMInfoModel.master11179DataDict.values());
 		for (Iterator <InstDefn> i = lMaster11179DataDictArr.iterator(); i.hasNext();) {
 			InstDefn lInstDefn = (InstDefn) i.next();
 			if (lInstDefn.className.compareTo ("PermissibleValue") == 0) {
@@ -56,7 +56,7 @@ class ISO11179DOMMDR extends Object {
 					if (lValArr != null) {
 						String lVMId = lValArr.get(0);
 						String lVMIdExt = "ValueMeaning" + "." + lVMId; 
-						InstDefn lVMInst = (InstDefn) InfoModel.master11179DataDict.get(lVMIdExt);
+						InstDefn lVMInst = (InstDefn) DOMInfoModel.master11179DataDict.get(lVMIdExt);
 						if (lVMInst != null) {
 							lValArr = lVMInst.genSlotMap.get("description");
 							if (lValArr != null) {
@@ -113,7 +113,7 @@ class ISO11179DOMMDR extends Object {
 			lSuffix = DOMInfoModel.getAttrIdentifier (lAttr.classNameSpaceIdNC, lAttr.parentClassTitle, lAttr.nameSpaceIdNC, lAttr.title);			
 			
 			lInstId = "DataElement" + "." + "DE" + "." + lSuffix;		
-			InstDefn lDEInst = InfoModel.master11179DataDict.get(lInstId);
+			InstDefn lDEInst = DOMInfoModel.master11179DataDict.get(lInstId);
 			if (lDEInst != null) {
 				lInstMap = lDEInst.genSlotMap;
 
@@ -146,13 +146,13 @@ class ISO11179DOMMDR extends Object {
 			boolean hasVD = false;
 			isEnumerated = false;
 			lInstId = "EnumeratedValueDomain" + "." + "EVD" + "." + lSuffix;
-			InstDefn lVDInst = InfoModel.master11179DataDict.get(lInstId);
+			InstDefn lVDInst = DOMInfoModel.master11179DataDict.get(lInstId);
 			if (lAttr.isEnumerated && lVDInst != null) {
 				hasVD = true;
 				isEnumerated = true;
 			} else {
 				lInstId = "NonEnumeratedValueDomain" + "." + "NEVD" + "." + lSuffix;
-				lVDInst = InfoModel.master11179DataDict.get(lInstId);
+				lVDInst = DOMInfoModel.master11179DataDict.get(lInstId);
 				if (lVDInst != null) {
 					hasVD = true;
 				}
@@ -233,7 +233,7 @@ class ISO11179DOMMDR extends Object {
 //							System.out.println("debug OverwriteFrom11179DataDict - get the permissible value meanings - lDOMPermVal.value:" + lDOMPermVal.value);
 							
 							// title:vm.0001_NASA_PDS_1.pds.DD_Class_Full.steward_id.111209
-							String lKey = "pv." + InfoModel.getAttrIdentifier(lAttr.classNameSpaceIdNC, lAttr.parentClassTitle, lAttr.nameSpaceIdNC, lAttr.title) + "." + lDOMPermVal.value;
+							String lKey = "pv." + DOMInfoModel.getAttrIdentifier(lAttr.classNameSpaceIdNC, lAttr.parentClassTitle, lAttr.nameSpaceIdNC, lAttr.title) + "." + lDOMPermVal.value;
 							String lValueMeaning = hashCodedValueMeaningMap.get(lKey);
 //							System.out.println("debug OverwriteFrom11179DataDict - get the permissible value meanings - - lKey:" + lKey);
 							if (lValueMeaning != null) {
@@ -252,9 +252,10 @@ class ISO11179DOMMDR extends Object {
 		// iterate through the associations
 		for (Iterator<DOMProp> i = DOMInfoModel.masterDOMPropArr.iterator(); i.hasNext();) {
 			DOMProp lProp = (DOMProp) i.next();
-			String lSuffix = InfoModel.getAttrIdentifier (lProp.classNameSpaceIdNC, lProp.parentClassTitle, lProp.nameSpaceIdNC, lProp.title);			
-			String lInstId = "Property" + "." + "PR" + "." + lSuffix;	
-			InstDefn lPRInst = InfoModel.master11179DataDict.get(lInstId);
+//			String lSuffix = DOMInfoModel.getAttrIdentifier (lProp.classNameSpaceIdNC, lProp.parentClassTitle, lProp.nameSpaceIdNC, lProp.title);			
+//			String lInstId = "Property" + "." + "PR" + "." + lSuffix;	
+			String lInstId = "Property" + "." + "PR" + "." + lProp.identifier;	
+			InstDefn lPRInst = DOMInfoModel.master11179DataDict.get(lInstId);
 			if (lPRInst == null) continue;
 			HashMap <String, ArrayList<String>> lInstMap = lPRInst.genSlotMap;
 			if (lInstMap == null) continue;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPinsDOM11179DD.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPinsDOM11179DD.java
@@ -1,0 +1,190 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin
+import java.util.*;
+
+/**
+ * Creates the in memory 11179 DD (InstDefn) from a Protege 11179 DD
+ *   getProtPins11179DD - gets a parsed a pins file - 11179 data dictionary
+ */
+
+class ProtPinsDOM11179DD extends Object {
+	ProtPins protPinsInst;
+	
+	public ProtPinsDOM11179DD () {
+
+		// Parse Protege Instance File - Parse InstDefn stored as follows.
+		// lInst.className - e.g. DataElement
+		// + lRegAuthId + "." + lInst.className + "." + lInst.title; 
+		// ++ InstDefn
+		DOMInfoModel.master11179DataDict = new TreeMap <String, InstDefn> ();
+		return;
+	}
+
+	/**
+	 *   Parses a pins file - 11179 data dictionary
+	 *   Updates/Creates a data dictionary 
+	 */
+	public void getProtPins11179DD (String lRegAuthId, String fname) throws Throwable {
+
+		// parse the PINS file
+		protPinsInst = new ProtPins();
+		protPinsInst.getProtInst("dd79", "dd79", fname);
+		
+		// iterate through the resultant instances and build the Master 11179 DD
+		HashMap <String, InstDefn> lInstMap = protPinsInst.instDict;
+		Set <String> set1 = lInstMap.keySet();
+		Iterator <String> iter1 = set1.iterator();
+		while(iter1.hasNext()) {
+			String lId = (String) iter1.next();
+			InstDefn lInst = (InstDefn) lInstMap.get(lId);
+	//		System.out.println("\ndebug getProtPins11179DD1 lInst.identifier:" + lInst.identifier);			
+	//		System.out.println("debug getProtPins11179DD2 lInst.title:" + lInst.title);
+	//		System.out.println("debug getProtPins11179DD3 lInst.rdfIdentifier:" + lInst.rdfIdentifier);
+	//		System.out.println("debug getProtPins11179DD4 lInst.className:" + lInst.className);
+			
+			// from the instance class, get the instance (a data element with its meta-attributes)
+			String lMast11179Id2 = lInst.className + "." + lInst.title; 
+			InstDefn lInst3 = DOMInfoModel.master11179DataDict.get(lMast11179Id2);
+			if (lInst3 == null) {
+				DOMInfoModel.master11179DataDict.put(lMast11179Id2, lInst);
+	//			System.out.println("debug getProtPins11179DataDict ++adding instance++ lMast11179Id2:" + lMast11179Id2 + "  lInst.rdfIdentifier:" + lInst.rdfIdentifier);
+			}
+		}
+		return;
+	}
+	
+	// get a string value from map
+	static public String getStringValue (HashMap <String, ArrayList<String>> lMap, String lMetaAttrName, String oVal) {
+//		System.out.println("debug getStringValue - lMetaAttrName:" + lMetaAttrName);
+		ArrayList<String> lValArr = lMap.get(lMetaAttrName); 
+		if (lValArr != null) {
+			int lValArrSize = lValArr.size();
+			if (lValArrSize == 1) {
+				String lVal = (String) lValArr.get(0);
+				if (! (lVal == null || (lVal.compareTo("")) == 0)) {
+					return lVal;
+				}
+			}
+		}
+		return oVal;
+		// returns the original value
+	}
+
+	// get a string value from map
+	static public String getStringValueUpdate (boolean isEscaped, HashMap <String, ArrayList<String>> lMap, String lMetaAttrName, String oVal) {
+//		System.out.println("debug getStringValue - lMetaAttrName:" + lMetaAttrName);
+		ArrayList<String> lValArr = lMap.get(lMetaAttrName); 
+		if (lValArr != null) {
+			int lValArrSize = lValArr.size();
+			if (lValArrSize == 1) {
+				String lVal = (String) lValArr.get(0);
+				if (! ((lVal == null) || ((lVal.compareTo("")) == 0) || ((lVal.indexOf("TBD")) == 0))) {
+					if (isEscaped) {
+						lVal = DOMInfoModel.unEscapeProtegeString(lVal);
+					}
+					if (lVal.compareTo(oVal) != 0) {
+						return lVal;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	// get a string value from map
+	static public String getStringValueUpdatePattern (boolean isEscaped, HashMap <String, ArrayList<String>> lMap, String lMetaAttrName, String oVal) {
+//		System.out.println("debug getStringValue - lMetaAttrName:" + lMetaAttrName);
+		ArrayList<String> lValArr = lMap.get(lMetaAttrName); 
+		if (lValArr != null) {
+			int lValArrSize = lValArr.size();
+			if (lValArrSize == 1) {
+				String lVal = (String) lValArr.get(0);
+				if (! ((lVal == null) || ((lVal.compareTo("")) == 0) || ((lVal.indexOf("TBD")) == 0))) {
+					if (isEscaped) {
+						lVal = DOMInfoModel.unEscapeProtegePatterns(lVal);
+					}
+					if (lVal.compareTo(oVal) != 0) {
+						return lVal;
+					}
+				}
+			}
+		}
+		return null;
+	}
+		
+	// dump master 11179 Data Dictionary
+	public void dumpMaster11179DataDict () {
+//		HashMap <String, ArrayList<String>> lMap = new HashMap <String, ArrayList<String>> ();
+
+		System.out.println("\n ======= Dump 11179 Data Dictionary =======");
+		Set <String> set2 = DOMInfoModel.master11179DataDict.keySet();
+		Iterator <String> iter2 = set2.iterator();	
+		while (iter2.hasNext()) {
+			// get the instance of the meta class - e.g. DataElement -> target_name
+			String lMetaClassInstId = (String) iter2.next();
+			System.out.println("\ndebug 11179 Dump -   lMetaClassInstId:" + lMetaClassInstId);
+			InstDefn lInst = DOMInfoModel.master11179DataDict.get(lMetaClassInstId);
+			if (lInst != null) {
+				System.out.println("                 -     Instance Name:" + lInst.title);
+//				lMap = lInst.genSlotMap;						
+				HashMap <String, ArrayList<String>> lMap = lInst.genSlotMap;						
+				Set <String> set3 = lMap.keySet();
+				Iterator <String> iter3 = set3.iterator();	
+				while (iter3.hasNext()) {
+					String lMetaAttrName = (String) iter3.next(); 
+					// get meta attributes - e.g. DataElement -> target_name -> deIdentifier
+//					System.out.println("                 -     Name:" + lMetaAttrName);
+					ArrayList <String> lValArr = lMap.get(lMetaAttrName); // an ArrayList; could have one value or many.
+					if (lValArr != null) {
+						int lValArrSize = lValArr.size();
+						if (lValArrSize == 1) {
+							String lVal = (String) lValArr.get(0);
+							if (! (lVal == null || (lVal.compareTo("")) == 0)) {
+								System.out.println("                 -     Name:" + lMetaAttrName + "   Value:" + lVal);
+							}
+						} else if (lValArrSize > 1) {
+							System.out.print("                 -     Name:" + lMetaAttrName + "  (Multi-valued) ");
+							for (Iterator <String> i = lValArr.iterator(); i.hasNext();) {
+								String lVal = (String) i.next();
+								if (lVal.compareTo("") != 0) {
+									System.out.print("Value:" + lVal + "; ");
+								}
+							}
+							System.out.println("");
+						}
+					}
+				}
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
Problem: During test of the new DOM Dictionary (Protege 11179dd.pins) file several classOrder values were found to be set to the default (9999). This resulted in an XML Schema with several validation errors.

Solution: Create a DOM version of ProtPins11179DD, namely ProtPinsDOM11179DD. Use the Property Id instead of the Attribute ID to create the dictionary element identifier.