### PR TITLE
Issue-#9 CCB-237 - Change Attribute doi to Data Type ASCII_DOI

### DIFF
--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Sun Mar 31 16:03:37 PDT 2019
+; Thu Aug 15 12:00:47 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -150,15 +150,8 @@
 
 	(dataTypeName "ASCII_VID"))
 
-([atm] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([cart] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
+([cart] of  %3AUNDEFINED
+)
 
 ([CD_Boolean] of  ConceptualDomain
 
@@ -1278,11 +1271,6 @@
 ([ComplexMSB8] of  DataType
 
 	(dataTypeName "ComplexMSB8"))
-
-([darts] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
 
 ([DataDesignWorkingGroup] of  Contact
 
@@ -25880,11 +25868,6 @@
 	(designationName "Value")
 	(isPreferred TRUE))
 
-([disp] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
 ([EVD.0001_NASA_PDS_1.pds.Agency.pds.name] of  EnumeratedValueDomain
 
 	(administrationRecord [DD_1.12.0.0])
@@ -34922,16 +34905,6 @@
 	(valueDomainFormat "TBD_format")
 	(versionIdentifier "1.12"))
 
-([geo] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([geom] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
 ([IEEE754LSBDouble] of  DataType
 
 	(dataTypeName "IEEE754LSBDouble"))
@@ -34948,30 +34921,13 @@
 
 	(dataTypeName "IEEE754MSBSingle"))
 
-([img] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([isda] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
+([img] of  %3AUNDEFINED
+)
 
 ([LI_English] of  LanguageIdentification
 
 	(countryIdentifier "USA")
 	(languageIdentifier "English"))
-
-([msn] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([naif] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
 
 ([NASA_PDS] of  Context
 
@@ -37039,7 +36995,7 @@
 
 	(administrationRecord [DD_1.12.0.0])
 	(dataIdentifier "NEVD.0001_NASA_PDS_1.pds.Citation_Information.pds.doi")
-	(datatype [ASCII_Short_String_Collapsed])
+	(datatype [ASCII_DOI])
 	(defaultUnitId "TBD_default_unit_id")
 	(maximumCharacterQuantity "TBD_maximum_characters")
 	(maximumValue "TBD_maximum_value")
@@ -39286,7 +39242,7 @@
 
 	(administrationRecord [DD_1.12.0.0])
 	(dataIdentifier "NEVD.0001_NASA_PDS_1.pds.Document.pds.doi")
-	(datatype [ASCII_Short_String_Collapsed])
+	(datatype [ASCII_DOI])
 	(defaultUnitId "TBD_default_unit_id")
 	(maximumCharacterQuantity "TBD_maximum_characters")
 	(maximumValue "TBD_maximum_value")
@@ -39643,7 +39599,7 @@
 
 	(administrationRecord [DD_1.12.0.0])
 	(dataIdentifier "NEVD.0001_NASA_PDS_1.pds.External_Reference.pds.doi")
-	(datatype [ASCII_Short_String_Collapsed])
+	(datatype [ASCII_DOI])
 	(defaultUnitId "TBD_default_unit_id")
 	(maximumCharacterQuantity "TBD_maximum_characters")
 	(maximumValue "TBD_maximum_value")
@@ -44893,7 +44849,7 @@
 
 	(administrationRecord [DD_1.12.0.0])
 	(dataIdentifier "NEVD.0001_NASA_PDS_1.pds.Source_Product_External.pds.doi")
-	(datatype [ASCII_Short_String_Collapsed])
+	(datatype [ASCII_DOI])
 	(defaultUnitId "TBD_default_unit_id")
 	(maximumCharacterQuantity "TBD_maximum_characters")
 	(maximumValue "TBD_maximum_value")
@@ -47328,16 +47284,11 @@
 	(contactPhone "818.354.6135")
 	(contactTitle "PDS_Standards_Coordinator"))
 
-([ppi] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([PR.0001_NASA_PDS_1.pds.Agency.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Agency.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Agency.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Agency.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47414,29 +47365,29 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Alias_List.pds.alias] of  Property
+([PR.0001_NASA_PDS_1.pds.Alias_List.pds.alias.Alias] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Alias_List.pds.alias")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Alias_List.pds.alias.Alias")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.associated_Special_Constants] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.associated_Special_Constants.Special_Constants] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.associated_Special_Constants")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.associated_Special_Constants.Special_Constants")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.associated_Statistics] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.associated_Statistics.Object_Statistics] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.associated_Statistics")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.associated_Statistics.Object_Statistics")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47459,11 +47410,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47477,29 +47428,29 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.has_Axis_Array] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.has_Axis_Array.Axis_Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.has_Axis_Array")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.has_Axis_Array.Axis_Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.has_Element_Array] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.has_Element_Array.Element_Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.has_Element_Array")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.has_Element_Array.Element_Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array.pds.local_internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Array.pds.local_internal_reference.Local_Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.local_internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array.pds.local_internal_reference.Local_Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47522,11 +47473,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_1D.pds.has_Axis_Array] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_1D.pds.has_Axis_Array.Axis_Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_1D.pds.has_Axis_Array")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_1D.pds.has_Axis_Array.Axis_Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47540,38 +47491,38 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_2D.pds.has_Axis_Array] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_2D.pds.has_Axis_Array.Axis_Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D.pds.has_Axis_Array")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D.pds.has_Axis_Array.Axis_Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_2D_Image.pds.has_Display_2d_Image] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_2D_Image.pds.has_Display_2d_Image.Display_2D_Image] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Image.pds.has_Display_2d_Image")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Image.pds.has_Display_2d_Image.Display_2D_Image")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_2D_Map.pds.has_Display_2d_Image] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_2D_Map.pds.has_Display_2d_Image.Display_2D_Image] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Map.pds.has_Display_2d_Image")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Map.pds.has_Display_2d_Image.Display_2D_Image")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_2D_Spectrum.pds.has_Display_2d_Image] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_2D_Spectrum.pds.has_Display_2d_Image.Display_2D_Image] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Spectrum.pds.has_Display_2d_Image")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_2D_Spectrum.pds.has_Display_2d_Image.Display_2D_Image")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -47585,11 +47536,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Array_3D.pds.has_Axis_Array] of  Property
+([PR.0001_NASA_PDS_1.pds.Array_3D.pds.has_Axis_Array.Axis_Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_3D.pds.has_Axis_Array")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Array_3D.pds.has_Axis_Array.Axis_Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49421,11 +49372,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Axis_Array.pds.has_Band_Bin_Set] of  Property
+([PR.0001_NASA_PDS_1.pds.Axis_Array.pds.has_Band_Bin_Set.Band_Bin_Set] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Axis_Array.pds.has_Band_Bin_Set")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Axis_Array.pds.has_Band_Bin_Set.Band_Bin_Set")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49547,11 +49498,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Band_Bin_Set.pds.has_band_bin] of  Property
+([PR.0001_NASA_PDS_1.pds.Band_Bin_Set.pds.has_band_bin.Band_Bin] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Band_Bin_Set.pds.has_band_bin")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Band_Bin_Set.pds.has_band_bin.Band_Bin")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49565,11 +49516,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Bundle.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Bundle.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Bundle.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Bundle.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49826,20 +49777,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Reference.Local_ID_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Reference.Local_ID_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Relation] of  Property
+([PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Relation.Local_ID_Relation] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Relation")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Composite_Structure.pds.has_Local_ID_Relation.Local_ID_Relation")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49880,65 +49831,65 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_discipline_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_discipline_area.Discipline_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_discipline_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_discipline_area.Discipline_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_investigation_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_investigation_area.Investigation_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_investigation_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_investigation_area.Investigation_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_mission_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_mission_area.Mission_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_mission_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_mission_area.Mission_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_observing_system] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_observing_system.Observing_System] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_observing_system")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_observing_system.Observing_System")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_primary_result_description] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_primary_result_description.Primary_Result_Summary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_primary_result_description")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_primary_result_description.Primary_Result_Summary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_target_identification] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_target_identification.Target_Identification] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_target_identification")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_target_identification.Target_Identification")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_time_coordinates] of  Property
+([PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_time_coordinates.Time_Coordinates] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_time_coordinates")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Context_Area.pds.has_time_coordinates.Time_Coordinates")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -49979,11 +49930,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1130")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object.Conceptual_Object")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object.Physical_Object] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1130")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50033,11 +49993,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.nssdc] of  Property
+([PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.nssdc.NSSDC] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1140")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.nssdc")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Data_Set_PDS3.pds.nssdc.NSSDC")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50096,20 +50056,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_attribute_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_attribute_reference.DD_Attribute_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_attribute_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_attribute_reference.DD_Attribute_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_class_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_class_reference.DD_Class_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_class_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Association.pds.dd_class_reference.DD_Class_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50213,11 +50173,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50231,11 +50191,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50276,20 +50236,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.value_domain_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.value_domain_entry.DD_Value_Domain] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.value_domain_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute.pds.value_domain_entry.DD_Value_Domain")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50330,11 +50290,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1150")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50420,11 +50380,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1160")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50438,11 +50398,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.value_domain_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.value_domain_entry.DD_Value_Domain_Full] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1170")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.value_domain_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Attribute_Full.pds.value_domain_entry.DD_Value_Domain_Full")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50483,20 +50443,29 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Association] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Association")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Association_External] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1090")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Association_External")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50519,11 +50488,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50555,11 +50524,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50591,20 +50560,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1130")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.dd_association] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.dd_association.DD_Association] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1140")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.dd_association")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.dd_association.DD_Association")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50690,11 +50659,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1150")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class_Full.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50735,11 +50704,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Permissible_Value.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Permissible_Value.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Permissible_Value.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Permissible_Value.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50762,11 +50731,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Permissible_Value_Full.pds.terminological_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Permissible_Value_Full.pds.terminological_entry.Terminological_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Permissible_Value_Full.pds.terminological_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Permissible_Value_Full.pds.terminological_entry.Terminological_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50807,20 +50776,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_attribute_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_attribute_reference.DD_Attribute_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1033")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_attribute_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_attribute_reference.DD_Attribute_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_class_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_class_reference.DD_Class_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1036")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_class_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.dd_class_reference.DD_Class_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50852,11 +50821,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.rule_statement] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Rule.pds.rule_statement.DD_Rule_Statement] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.rule_statement")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Rule.pds.rule_statement.DD_Rule_Statement")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -50969,11 +50938,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Value_Domain.pds.permissible_value] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Value_Domain.pds.permissible_value.DD_Permissible_Value] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Value_Domain.pds.permissible_value")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Value_Domain.pds.permissible_value.DD_Permissible_Value")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51077,11 +51046,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.DD_Value_Domain_Full.pds.permissible_value] of  Property
+([PR.0001_NASA_PDS_1.pds.DD_Value_Domain_Full.pds.permissible_value.DD_Permissible_Value_Full] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1120")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Value_Domain_Full.pds.permissible_value")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Value_Domain_Full.pds.permissible_value.DD_Permissible_Value_Full")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51131,20 +51100,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet1] of  Property
+([PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet1.Group_Facet1] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet1")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet1.Group_Facet1")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet2] of  Property
+([PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet2.Group_Facet2] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet2")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Discipline_Facets.pds.has_Group_Facet2.Group_Facet2")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51194,11 +51163,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Document.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Document.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51248,11 +51217,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Document.pds.has_document_edition] of  Property
+([PR.0001_NASA_PDS_1.pds.Document.pds.has_document_edition.Document_Edition] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1095")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document.pds.has_document_edition")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document.pds.has_document_edition.Document_Edition")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51302,11 +51271,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Document_Edition.pds.has_document_file] of  Property
+([PR.0001_NASA_PDS_1.pds.Document_Edition.pds.has_document_file.Document_File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document_Edition.pds.has_document_file")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Document_Edition.pds.has_document_file.Document_File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51392,11 +51361,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Encoded_Byte_Stream.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Encoded_Byte_Stream.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Encoded_Byte_Stream.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Encoded_Byte_Stream.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51527,11 +51496,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Facility.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Facility.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Facility.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Facility.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51581,20 +51550,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Special_Constants] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Special_Constants.Special_Constants] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Special_Constants")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Special_Constants.Special_Constants")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Statistics] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Statistics.Field_Statistics] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Statistics")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.associated_Statistics.Field_Statistics")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51644,11 +51613,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.has_Packed_Data_Fields] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Binary.pds.has_Packed_Data_Fields.Packed_Data_Fields] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1120")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.has_Packed_Data_Fields")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Binary.pds.has_Packed_Data_Fields.Packed_Data_Fields")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51689,11 +51658,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Bit.pds.associated_Special_Constants] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Bit.pds.associated_Special_Constants.Special_Constants] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Bit.pds.associated_Special_Constants")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Bit.pds.associated_Special_Constants.Special_Constants")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51797,20 +51766,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Special_Constants] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Special_Constants.Special_Constants] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Special_Constants")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Special_Constants.Special_Constants")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Statistics] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Statistics.Field_Statistics] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Statistics")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Character.pds.associated_Statistics.Field_Statistics")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51905,20 +51874,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Special_Constants] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Special_Constants.Special_Constants] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Special_Constants")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Special_Constants.Special_Constants")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Statistics] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Statistics.Field_Statistics] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Statistics")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Delimited.pds.associated_Statistics.Field_Statistics")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -51995,11 +51964,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Field_Statistics.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Field_Statistics.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Statistics.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Field_Statistics.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52085,11 +52054,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52139,344 +52108,956 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_File] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_File")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_File] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_File")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Image] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Image")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_File] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_File")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Map] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Map")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_File] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_File")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Spectrum] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_2D_Spectrum")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_File] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_File")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Movie] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Movie")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Array_3D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Checksum_Manifest] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Checksum_Manifest")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Encoded_Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Encoded_Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Encoded_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Encoded_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Stream_Text] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Stream_Text")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Ancillary.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_tagged_data_object.Encoded_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Binary.pds.has_tagged_data_object.Encoded_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_File.File] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_File.File")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_1D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_1D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Map] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Map")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_2D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Movie] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Movie")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Array_3D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Encoded_Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Encoded_Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Encoded_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Encoded_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Stream_Text] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Stream_Text")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Browse.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_File.File] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_File.File")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_tagged_data_object.Checksum_Manifest] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Checksum_Manifest.pds.has_tagged_data_object.Checksum_Manifest")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_File.File] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_File.File")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_tagged_data_object.Encoded_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Encoded_Image.pds.has_tagged_data_object.Encoded_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_File.File] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_File.File")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_tagged_data_object.Inventory] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Inventory.pds.has_tagged_data_object.Inventory")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_File.File] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_File.File")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object.Table_Character] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object.Table_Character")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object2] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object2.Header] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object2")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Metadata.pds.has_tagged_data_object2.Header")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_tagged_data_object.Encoded_Native] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Native.pds.has_tagged_data_object.Encoded_Native")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_composite_structure] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_composite_structure.Composite_Structure] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1015")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_composite_structure")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_composite_structure.Composite_Structure")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_composite_structure] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_1D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_1D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Map] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Map")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_2D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Movie] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Movie")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Array_3D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Encoded_Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Encoded_Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Stream_Text] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Stream_Text")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_composite_structure.Composite_Structure] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1015")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_composite_structure")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_composite_structure.Composite_Structure")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_1D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_1D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Map] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Map")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_2D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Movie] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Movie")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Spectrum] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Array_3D_Spectrum")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Byte_Stream] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Byte_Stream")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Encoded_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Header] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Header")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Parsable_Byte_Stream] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Parsable_Byte_Stream")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Stream_Text] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Stream_Text")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Observational_Supplemental.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_tagged_data_object.Service_Description] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Service_Description.pds.has_tagged_data_object.Service_Description")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_tagged_data_object.Manifest_SIP_Deep_Archive] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SIP_Deep_Archive.pds.has_tagged_data_object.Manifest_SIP_Deep_Archive")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_tagged_data_object.SPICE_Kernel] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_SPICE_Kernel.pds.has_tagged_data_object.SPICE_Kernel")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_tagged_data_object.Stream_Text] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Text.pds.has_tagged_data_object.Stream_Text")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_tagged_data_object.Transfer_Manifest] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Transfer_Manifest.pds.has_tagged_data_object.Transfer_Manifest")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object.Table_Character] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object.Table_Character")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object2] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object.Table_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object.Table_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object2.Header] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1015")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object2")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_Update.pds.has_tagged_data_object2.Header")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_File] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_File.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_File")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_File.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_tagged_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_tagged_data_object.XML_Schema] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_tagged_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.File_Area_XML_Schema.pds.has_tagged_data_object.XML_Schema")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52589,11 +53170,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary] of  Property
+([PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary.Field_Binary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary.Field_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary.Group_Field_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Binary.pds.has_Group_Field_Binary.Group_Field_Binary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52616,20 +53206,38 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character] of  Property
+([PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character.Field_Character] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character.Field_Character")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped] of  Property
+([PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character.Group_Field_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Character.pds.has_Group_Field_Character.Group_Field_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped.Field_Delimited] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped.Field_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped.Group_Field_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Group_Field_Delimited.pds.has_Delimited_Field_Grouped.Group_Field_Delimited")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52652,20 +53260,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.alias_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.alias_list.Alias_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.alias_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.alias_list.Alias_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.citation_information] of  Property
+([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.citation_information.Citation_Information] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1075")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.citation_information")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.citation_information.Citation_Information")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52688,11 +53296,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.modification_history] of  Property
+([PR.0001_NASA_PDS_1.pds.Identification_Area.pds.modification_history.Modification_History] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.modification_history")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Identification_Area.pds.modification_history.Modification_History")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52751,29 +53359,29 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Checksum_Manifest] of  Property
+([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Checksum_Manifest.File_Area_Checksum_Manifest] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Checksum_Manifest")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Checksum_Manifest.File_Area_Checksum_Manifest")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Transfer_Manifest] of  Property
+([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Transfer_Manifest.File_Area_Transfer_Manifest] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Transfer_Manifest")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.has_Transfer_Manifest.File_Area_Transfer_Manifest")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52814,20 +53422,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.has_manifest] of  Property
+([PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.has_manifest.File_Area_SIP_Deep_Archive] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.has_manifest")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.has_manifest.File_Area_SIP_Deep_Archive")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52859,11 +53467,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52886,11 +53494,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.has_Property_Maps] of  Property
+([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.has_Property_Maps.Property_Maps] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1120")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.has_Property_Maps")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.has_Property_Maps.Property_Maps")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52913,29 +53521,29 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_attribute] of  Property
+([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_attribute.DD_Attribute] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_attribute")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_attribute.DD_Attribute")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_class] of  Property
+([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_class.DD_Class] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1100")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_class")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_class.DD_Class")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_rule] of  Property
+([PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_rule.DD_Rule] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_rule")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Ingest_LDD.pds.local_rule.DD_Rule")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52967,11 +53575,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Instrument.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Instrument.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -52985,11 +53593,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Instrument.pds.has_type_list_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Instrument.pds.has_type_list_area.Type_List_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1015")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument.pds.has_type_list_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument.pds.has_type_list_area.Type_List_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53048,11 +53656,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Instrument_Host.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Instrument_Host.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_Host.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_Host.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53120,11 +53728,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Instrument_Host_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Instrument_Host_PDS3.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_Host_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_Host_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53165,11 +53773,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Instrument_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Instrument_PDS3.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Instrument_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53273,11 +53881,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Investigation.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Investigation.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Investigation.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Investigation.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53327,11 +53935,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Investigation_Area.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Investigation_Area.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Investigation_Area.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Investigation_Area.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53444,11 +54052,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Mission_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Mission_PDS3.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Mission_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Mission_PDS3.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53525,20 +54133,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Modification_History.pds.modification_detail] of  Property
+([PR.0001_NASA_PDS_1.pds.Modification_History.pds.modification_detail.Modification_Detail] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Modification_History.pds.modification_detail")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Modification_History.pds.modification_detail.Modification_Detail")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Node.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Node.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Node.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Node.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53597,11 +54205,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Object_Statistics.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Object_Statistics.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1120")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Object_Statistics.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Object_Statistics.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53696,47 +54304,56 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_investigation_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_investigation_area.Investigation_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_investigation_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_investigation_area.Investigation_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_observing_system] of  Property
+([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_observing_system.Observing_System] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_observing_system")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_observing_system.Observing_System")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_target_identification] of  Property
+([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_target_identification.Target_Identification] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_target_identification")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_target_identification.Target_Identification")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_time_coordinates] of  Property
+([PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_time_coordinates.Time_Coordinates] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_time_coordinates")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observation_Area.pds.has_time_coordinates.Time_Coordinates")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object.Conceptual_Object")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object.Physical_Object] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1040")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53759,11 +54376,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observing_System.pds.observing_system_component] of  Property
+([PR.0001_NASA_PDS_1.pds.Observing_System.pds.observing_system_component.Observing_System_Component] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System.pds.observing_system_component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System.pds.observing_system_component.Observing_System_Component")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53777,20 +54394,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.external_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.external_reference.External_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.external_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.external_reference.External_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Observing_System_Component.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53813,11 +54430,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Other.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Other.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Other.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Other.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53849,20 +54466,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Packed_Data_Fields.pds.has_Field_Bit] of  Property
+([PR.0001_NASA_PDS_1.pds.Packed_Data_Fields.pds.has_Field_Bit.Field_Bit] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Packed_Data_Fields.pds.has_Field_Bit")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Packed_Data_Fields.pds.has_Field_Bit.Field_Bit")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Parsable_Byte_Stream.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Parsable_Byte_Stream.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Parsable_Byte_Stream.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Parsable_Byte_Stream.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -53921,11 +54538,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.PDS_Affiliate.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.PDS_Affiliate.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1130")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.PDS_Affiliate.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.PDS_Affiliate.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -54020,11 +54637,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.PDS_Guest.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.PDS_Guest.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.PDS_Guest.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.PDS_Guest.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -54092,11 +54709,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.has_Science_Facet] of  Property
+([PR.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.has_Science_Facet.Science_Facets] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.has_Science_Facet")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.has_Science_Facet.Science_Facets")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -54137,830 +54754,956 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product.pds.has_identification_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product.pds.has_identification_area.Identification_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product.pds.has_identification_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product.pds.has_identification_area.Identification_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.has_Information_Package_Component] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.has_Information_Package_Component.Information_Package_Component] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.has_Information_Package_Component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.has_Information_Package_Component.Information_Package_Component")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.product_data_object.Archival_Information_Package] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.product_data_object.Archival_Information_Package")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_AIP.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_AIP.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.context_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.context_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.file_area.File_Area_Ancillary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.file_area.File_Area_Ancillary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Ancillary.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.product_data_object.DD_Attribute_Full] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.product_data_object.DD_Attribute_Full")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Attribute_Definition.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.context_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1005")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.context_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.file_area.File_Area_Browse] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.file_area.File_Area_Browse")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Browse.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Browse.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.context_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.context_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.file_area.File_Area_Text] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.file_area.File_Area_Text")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.member_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.member_entry.Bundle_Member_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.member_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.member_entry.Bundle_Member_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.product_data_object.Bundle] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.product_data_object.Bundle")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Bundle.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.product_data_object.DD_Class_Full] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.product_data_object.DD_Class_Full")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Class_Definition.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.context_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.context_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.file_area_inventory] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.file_area_inventory.File_Area_Inventory] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.file_area_inventory")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.file_area_inventory.File_Area_Inventory")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.product_data_object.Collection] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.product_data_object.Collection")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Collection.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Collection.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Context.pds.has_discipline_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.has_discipline_area.Discipline_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.has_discipline_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.has_discipline_area.Discipline_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Agency] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Agency")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Context.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.has_Information_Package_Component] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.has_Information_Package_Component")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Airborne] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Airborne")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.has_Information_Package_Component] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.has_Information_Package_Component")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Facility] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Facility")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Document.pds.context_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.context_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Document.pds.has_document] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Instrument] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.has_document")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Instrument")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Document.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.file_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.file_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.file_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.file_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Instrument_Host] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Instrument_Host")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Native.pds.context_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.context_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Native.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Investigation] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Investigation")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Native.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Node] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Node")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area_supplemental] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Other] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Other")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.PDS_Affiliate] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.PDS_Affiliate")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.PDS_Guest] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.PDS_Guest")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Resource] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Resource")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Target] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Target")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Telescope] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.product_data_object.Telescope")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Context.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Context.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.product_data_object.Data_Set_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.product_data_object.Data_Set_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Data_Set_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.has_Information_Package_Component.Information_Package_Component] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.has_Information_Package_Component.Information_Package_Component")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.product_data_object.Dissemination_Information_Package] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.product_data_object.Dissemination_Information_Package")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.has_Information_Package_Component.Information_Package_Component] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.has_Information_Package_Component.Information_Package_Component")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.product_data_object.DIP_Deep_Archive] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.product_data_object.DIP_Deep_Archive")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_DIP_Deep_Archive.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Document.pds.context_area.Context_Area] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.context_area.Context_Area")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Document.pds.has_document.Document] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.has_document.Document")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Document.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Document.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.file_area.File_Area_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.file_area.File_Area_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Repository.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.file_area.File_Area_Text] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.file_area.File_Area_Text")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_File_Text.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.product_data_object.Instrument_Host_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.product_data_object.Instrument_Host_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_Host_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.product_data_object.Instrument_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.product_data_object.Instrument_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Instrument_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.file_area.File_Area_Metadata] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.file_area.File_Area_Metadata")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Metadata_Supplemental.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.product_data_object.Mission_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.product_data_object.Mission_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Mission_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Native.pds.context_area.Context_Area] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.context_area.Context_Area")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Native.pds.file_area.File_Area_Native] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.file_area.File_Area_Native")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Native.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Native.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area.File_Area_Observational] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area.File_Area_Observational")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area_supplemental.File_Area_Observational_Supplemental] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area_supplemental")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.file_area_supplemental.File_Area_Observational_Supplemental")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.observation_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.observation_area.Observation_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.observation_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.observation_area.Observation_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Observational.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Observational.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.file_area.File_Area_Binary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.file_area.File_Area_Binary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Proxy_PDS3.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Service.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Service.pds.file_area.File_Area_Service_Description] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.file_area.File_Area_Service_Description")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Service.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Service.pds.product_data_object.Service] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.product_data_object.Service")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Service.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Service.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Service.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.has_Information_Package_Component] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.has_Information_Package_Component.Information_Package_Component] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.has_Information_Package_Component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.has_Information_Package_Component.Information_Package_Component")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.product_data_object.Submission_Information_Package] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.product_data_object.Submission_Information_Package")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.has_Information_Package_Component] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.has_Information_Package_Component.Information_Package_Component_Deep_Archive] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.has_Information_Package_Component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.has_Information_Package_Component.Information_Package_Component_Deep_Archive")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.product_data_object.SIP_Deep_Archive] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.product_data_object.SIP_Deep_Archive")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SIP_Deep_Archive.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Software.pds.product_description] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Software.pds.product_description.Software] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.product_description")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.product_description.Software")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Software.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Software.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Binary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Binary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.context_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.context_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Script] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Script")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.subscriber] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.subscriber")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.file_area] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.file_area")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.reference_list] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.reference_list")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Update.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Source] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Software.pds.software_format_set.Software_Source")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Update.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Update.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.file_area.File_Area_SPICE_Kernel] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.file_area.File_Area_SPICE_Kernel")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_SPICE_Kernel.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.product_data_object] of  Property
-
-	(administrationRecord [DD_1.12.0.0])
-	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.product_data_object")
-	(registeredBy [RA_0001_NASA_PDS_1])
-	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
-	(versionIdentifier "1.12"))
-
-([PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.product_data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.subscriber.Subscriber_PDS3] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.product_data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Subscription_PDS3.pds.subscriber.Subscriber_PDS3")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.product_data_object.Target_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.product_data_object.Target_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Target_PDS3.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.context_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.file_area.File_Area_Encoded_Image] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.file_area.File_Area_Encoded_Image")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Thumbnail.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Update.pds.file_area.File_Area_Update] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1030")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.file_area.File_Area_Update")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Update.pds.product_data_object.Update] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.product_data_object.Update")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Update.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Update.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.product_data_object.Volume_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.product_data_object.Volume_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.product_data_object.Volume_Set_PDS3] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.product_data_object.Volume_Set_PDS3")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.reference_list.Reference_List] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1010")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Volume_Set_PDS3.pds.reference_list.Reference_List")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.context_area.Context_Area] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1005")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.context_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.context_area.Context_Area")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.file_area] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.file_area.File_Area_XML_Schema] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.file_area")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.file_area.File_Area_XML_Schema")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.reference_list] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.reference_list.Reference_List] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.reference_list")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_XML_Schema.pds.reference_list.Reference_List")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.file] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.file.File] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.file")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.file.File")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.has_zip] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.has_zip.Zip] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.has_zip")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.has_zip.Zip")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Product_Zipped.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -54983,11 +55726,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Property_Map.pds.has_Property_Map_Entry] of  Property
+([PR.0001_NASA_PDS_1.pds.Property_Map.pds.has_Property_Map_Entry.Property_Map_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Property_Map.pds.has_Property_Map_Entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Property_Map.pds.has_Property_Map_Entry.Property_Map_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55091,11 +55834,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Property_Maps.pds.has_property_map] of  Property
+([PR.0001_NASA_PDS_1.pds.Property_Maps.pds.has_property_map.Property_Map] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Property_Maps.pds.has_property_map")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Property_Maps.pds.has_property_map.Property_Map")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55127,11 +55870,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Quaternion.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Quaternion.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Quaternion.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Quaternion.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55163,11 +55906,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Quaternion.pds.quaternion_component] of  Property
+([PR.0001_NASA_PDS_1.pds.Quaternion.pds.quaternion_component.Quaternion_Component] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Quaternion.pds.quaternion_component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Quaternion.pds.quaternion_component.Quaternion_Component")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55244,11 +55987,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field] of  Property
+([PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field.Field_Binary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field.Field_Binary")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field.Group_Field_Binary] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Binary.pds.has_Table_Field.Group_Field_Binary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55262,11 +56014,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field] of  Property
+([PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field.Field_Character] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field.Field_Character")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field.Group_Field_Character] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Character.pds.has_Character_Field.Group_Field_Character")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55280,11 +56041,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field] of  Property
+([PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field.Field_Delimited] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field.Field_Delimited")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field.Group_Field_Delimited] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1020")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Record_Delimited.pds.has_Delimited_Field.Group_Field_Delimited")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55298,47 +56068,47 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Reference_List.pds.external_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Reference_List.pds.external_reference.External_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.external_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.external_reference.External_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Reference_List.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Reference_List.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1010")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_external] of  Property
+([PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_external.Source_Product_External] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_external")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_external.Source_Product_External")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_internal] of  Property
+([PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_internal.Source_Product_Internal] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_internal")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Reference_List.pds.source_product_internal.Source_Product_Internal")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Resource.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Resource.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Resource.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Resource.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55388,11 +56158,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Science_Facets.pds.has_Discipline_Facets] of  Property
+([PR.0001_NASA_PDS_1.pds.Science_Facets.pds.has_Discipline_Facets.Discipline_Facets] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Science_Facets.pds.has_Discipline_Facets")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Science_Facets.pds.has_Discipline_Facets.Discipline_Facets")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55424,11 +56194,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Service.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Service.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Service.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Service.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55550,11 +56320,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Software.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Software.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55631,11 +56401,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Software_Binary.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Software_Binary.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Binary.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Binary.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55703,11 +56473,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Software_Script.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Software_Script.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Script.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Script.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -55757,11 +56527,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Software_Source.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Software_Source.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1110")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Source.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Software_Source.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56108,11 +56878,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Base.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Base.pds.data_object.Digital_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Base.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Base.pds.data_object.Digital_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56144,11 +56914,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Binary.pds.has_Record] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Binary.pds.has_Record.Record_Binary] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Binary.pds.has_Record")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Binary.pds.has_Record.Record_Binary")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56162,20 +56932,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Binary.pds.uniformly_sampled] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Binary.pds.uniformly_sampled.Uniformly_Sampled] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Binary.pds.uniformly_sampled")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Binary.pds.uniformly_sampled.Uniformly_Sampled")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Character.pds.has_Record] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Character.pds.has_Record.Record_Character] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Character.pds.has_Record")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Character.pds.has_Record.Record_Character")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56189,11 +56959,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Character.pds.uniformly_sampled] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Character.pds.uniformly_sampled.Uniformly_Sampled] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1020")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Character.pds.uniformly_sampled")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Character.pds.uniformly_sampled.Uniformly_Sampled")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56207,11 +56977,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.has_delimited_record] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.has_delimited_record.Record_Delimited] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.has_delimited_record")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.has_delimited_record.Record_Delimited")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56243,20 +57013,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.uniformly_sampled] of  Property
+([PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.uniformly_sampled.Uniformly_Sampled] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.uniformly_sampled")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Table_Delimited.pds.uniformly_sampled.Uniformly_Sampled")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Target.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Target.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56306,11 +57076,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Target_Identification.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Target_Identification.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1050")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target_Identification.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target_Identification.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56333,11 +57103,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Target_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Target_PDS3.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1070")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Target_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56423,11 +57193,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Telescope.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Telescope.pds.data_object.Physical_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Telescope.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Telescope.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56468,11 +57238,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Term_Map_SKOS.pds.Term_Map_SKOS_to_Term_Entry_SKOS] of  Property
+([PR.0001_NASA_PDS_1.pds.Term_Map_SKOS.pds.Term_Map_SKOS_to_Term_Entry_SKOS.Terminological_Entry_SKOS] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "9999")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Term_Map_SKOS.pds.Term_Map_SKOS_to_Term_Entry_SKOS")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Term_Map_SKOS.pds.Term_Map_SKOS_to_Term_Entry_SKOS.Terminological_Entry_SKOS")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -56522,11 +57292,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Terminological_Entry.pds.source] of  Property
+([PR.0001_NASA_PDS_1.pds.Terminological_Entry.pds.source.External_Reference_Extended] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Terminological_Entry.pds.source")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Terminological_Entry.pds.source.External_Reference_Extended")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -57692,11 +58462,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Update.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Update.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -57719,11 +58489,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Update.pds.update_entry] of  Property
+([PR.0001_NASA_PDS_1.pds.Update.pds.update_entry.Update_Entry] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update.pds.update_entry")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update.pds.update_entry.Update_Entry")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -57764,11 +58534,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Update_Entry.pds.internal_reference] of  Property
+([PR.0001_NASA_PDS_1.pds.Update_Entry.pds.internal_reference.Internal_Reference] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1040")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update_Entry.pds.internal_reference")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Update_Entry.pds.internal_reference.Internal_Reference")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -57953,11 +58723,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Vector.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Vector.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1080")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Vector.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Vector.pds.data_object.Conceptual_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -58016,11 +58786,11 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Vector.pds.vector_component] of  Property
+([PR.0001_NASA_PDS_1.pds.Vector.pds.vector_component.Vector_Component] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1090")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Vector.pds.vector_component")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Vector.pds.vector_component.Vector_Component")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -58142,11 +58912,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1140")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object.Conceptual_Object")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object.Physical_Object] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1140")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -58241,11 +59020,20 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
-([PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object] of  Property
+([PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object.Conceptual_Object] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1060")
-	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object.Conceptual_Object")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object.Physical_Object] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "1060")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Volume_Set_PDS3.pds.data_object.Physical_Object")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -58330,11 +59118,6 @@
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
-
-([psa] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
 
 ([pv.0001_NASA_PDS_1.pds.Agency.pds.name.-361578825] of  PermissibleValue
 
@@ -69521,26 +70304,6 @@
 	(registrar [PDS_Registrar])
 	(registrationAuthorityIdentifier_v [0001_NASA_PDS_1]))
 
-([rings] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([rs] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([rssa] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
-([sbn] of  Steward
-
-	(contact [PDS_Standards_Coordinator])
-	(organization [RA_0001_NASA_PDS_1]))
-
 ([SignedBitString] of  DataType
 
 	(dataTypeName "SignedBitString"))
@@ -76526,9 +77289,9 @@
 	(measureName "Units_of_Acceleration")
 	(precision "TBD_precision")
 	(unitId
-		"m%2Fs**2"
 		"cm%2Fs**2"
-		"km%2Fs**2"))
+		"km%2Fs**2"
+		"m%2Fs**2"))
 
 ([Units_of_Amount_Of_Substance] of  UnitOfMeasure
 
@@ -76543,12 +77306,12 @@
 	(measureName "Units_of_Angle")
 	(precision "TBD_precision")
 	(unitId
-		"deg"
-		"rad"
-		"mrad"
-		"arcsec"
 		"arcmin"
-		"hr"))
+		"arcsec"
+		"deg"
+		"hr"
+		"mrad"
+		"rad"))
 
 ([Units_of_Angular_Velocity] of  UnitOfMeasure
 
@@ -76556,9 +77319,9 @@
 	(measureName "Units_of_Angular_Velocity")
 	(precision "TBD_precision")
 	(unitId
+		"deg%2Fday"
 		"deg%2Fs"
-		"rad%2Fs"
-		"deg%2Fday"))
+		"rad%2Fs"))
 
 ([Units_of_Area] of  UnitOfMeasure
 
@@ -76582,10 +77345,10 @@
 	(measureName "Units_of_Energy")
 	(precision "TBD_precision")
 	(unitId
-		"eV"
-		"keV"
+		"J"
 		"MeV"
-		"J"))
+		"eV"
+		"keV"))
 
 ([Units_of_Frame_Rate] of  UnitOfMeasure
 
@@ -76607,14 +77370,14 @@
 	(measureName "Units_of_Length")
 	(precision "TBD_precision")
 	(unitId
-		"m"
-		"km"
-		"nm"
-		"mm"
-		"cm"
 		"AU"
 		"Angstrom"
-		"micrometer"))
+		"cm"
+		"km"
+		"m"
+		"micrometer"
+		"mm"
+		"nm"))
 
 ([Units_of_Map_Scale] of  UnitOfMeasure
 
@@ -76622,10 +77385,10 @@
 	(measureName "Units_of_Map_Scale")
 	(precision "TBD_precision")
 	(unitId
-		"m%2Fpixel"
-		"pixel%2Fdeg"
 		"km%2Fpixel"
-		"mm%2Fpixel"))
+		"m%2Fpixel"
+		"mm%2Fpixel"
+		"pixel%2Fdeg"))
 
 ([Units_of_Mass] of  UnitOfMeasure
 
@@ -76633,8 +77396,8 @@
 	(measureName "Units_of_Mass")
 	(precision "TBD_precision")
 	(unitId
-		"kg"
-		"g"))
+		"g"
+		"kg"))
 
 ([Units_of_Misc] of  UnitOfMeasure
 
@@ -76642,9 +77405,9 @@
 	(measureName "Units_of_Misc")
 	(precision "TBD_precision")
 	(unitId
-		"pixel"
 		"DN"
-		"electron%2FDN"))
+		"electron%2FDN"
+		"pixel"))
 
 ([Units_of_None] of  UnitOfMeasure
 
@@ -76666,8 +77429,8 @@
 	(measureName "Units_of_Pixel_Resolution_Angular")
 	(precision "TBD_precision")
 	(unitId
-		"deg%2Fpixel"
 		"arcsec%2Fpixel"
+		"deg%2Fpixel"
 		"radian%2Fpixel"))
 
 ([Units_of_Pixel_Resolution_Linear] of  UnitOfMeasure
@@ -76686,10 +77449,10 @@
 	(measureName "Units_of_Pixel_Resolution_Map")
 	(precision "TBD_precision")
 	(unitId
+		"deg%2Fpixel"
 		"km%2Fpixel"
 		"m%2Fpixel"
-		"mm%2Fpixel"
-		"deg%2Fpixel"))
+		"mm%2Fpixel"))
 
 ([Units_of_Pixel_Scale_Angular] of  UnitOfMeasure
 
@@ -76697,8 +77460,8 @@
 	(measureName "Units_of_Pixel_Scale_Angular")
 	(precision "TBD_precision")
 	(unitId
-		"pixel%2Fdeg"
 		"pixel%2Farcsec"
+		"pixel%2Fdeg"
 		"pixel%2Fradian"))
 
 ([Units_of_Pixel_Scale_Linear] of  UnitOfMeasure
@@ -76724,10 +77487,10 @@
 	(measureName "Units_of_Pressure")
 	(precision "TBD_precision")
 	(unitId
+		"Pa"
 		"bar"
-		"mbar"
 		"hPa"
-		"Pa"))
+		"mbar"))
 
 ([Units_of_Radiance] of  UnitOfMeasure
 
@@ -76744,8 +77507,8 @@
 	(measureName "Units_of_Rates")
 	(precision "TBD_precision")
 	(unitId
-		"kilobits%2Fs"
-		"counts%2Fbin"))
+		"counts%2Fbin"
+		"kilobits%2Fs"))
 
 ([Units_of_Solid_Angle] of  UnitOfMeasure
 
@@ -76763,11 +77526,11 @@
 		"SFU"
 		"W*m**-2*Hz**-1"
 		"W*m**-2*nm**-1"
-		"uW*cm**-2*um**-1"
 		"W*m**-3"
 		"W%2Fm**2%2FHz"
 		"W%2Fm**2%2Fnm"
 		"W%2Fm**3"
+		"uW*cm**-2*um**-1"
 		"μW%2Fcm**2%2Fμm"))
 
 ([Units_of_Spectral_Radiance] of  UnitOfMeasure
@@ -76780,11 +77543,11 @@
 		"W*m**-2*sr**-1*nm**-1"
 		"W*m**-2*sr**-1*um**-1"
 		"W*m**-3*sr**-1"
-		"uW*cm**-2*sr**-1*um**-1"
 		"W%2Fm**2%2Fsr%2FHz"
 		"W%2Fm**2%2Fsr%2Fnm"
 		"W%2Fm**2%2Fsr%2Fμm"
 		"W%2Fm**3%2Fsr"
+		"uW*cm**-2*sr**-1*um**-1"
 		"μW%2Fcm**2%2Fsr%2Fμm"))
 
 ([Units_of_Storage] of  UnitOfMeasure
@@ -76809,14 +77572,14 @@
 	(measureName "Units_of_Time")
 	(precision "TBD_precision")
 	(unitId
-		"s"
-		"ms"
+		"day"
+		"hr"
+		"julian day"
 		"microseconds"
 		"min"
-		"hr"
-		"day"
-		"yr"
-		"julian day"))
+		"ms"
+		"s"
+		"yr"))
 
 ([Units_of_Velocity] of  UnitOfMeasure
 
@@ -76824,9 +77587,9 @@
 	(measureName "Units_of_Velocity")
 	(precision "TBD_precision")
 	(unitId
-		"m%2Fs"
 		"cm%2Fs"
-		"km%2Fs"))
+		"km%2Fs"
+		"m%2Fs"))
 
 ([Units_of_Voltage] of  UnitOfMeasure
 
@@ -76852,12 +77615,12 @@
 	(measureName "Units_of_Wavenumber")
 	(precision "TBD_precision")
 	(unitId
-		"nm**-1"
-		"cm**-1"
-		"m**-1"
 		"1%2Fcm"
 		"1%2Fm"
-		"1%2Fnm"))
+		"1%2Fnm"
+		"cm**-1"
+		"m**-1"
+		"nm**-1"))
 
 ([UnsignedBitString] of  DataType
 


### PR DESCRIPTION
Change data type of attribute <doi> to ASCII_DOI.
	doi in Citation_Information
	doi in Document
	doi in External_Reference
	doi in Source_Product_External

Install the new dd1179.pins file.
   This file contains the definitions of all attributes in the PDS4 Information Model.
   The difference between this, the DOM version and the original MOF version is that the property identifiers have an additional suffix to ensure uniqueness.