### PR TITLE
Issue #17 CCB-252_Make_Science_Facets_wavelength_range_nillable

### DIFF
--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Sat Aug 17 12:46:41 PDT 2019
+; Sat Aug 17 14:56:54 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -10314,7 +10314,7 @@
 	(administrationRecord [DD_1.12.0.0])
 	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Science_Facets.pds.wavelength_range")
 	(expressedBy [DEC_TBD_classConcept])
-	(isNillable "false")
+	(isNillable "true")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(representing [EVD.0001_NASA_PDS_1.pds.Science_Facets.pds.wavelength_range])


### PR DESCRIPTION
Make the attribute <Science_Facets.wavelength_range> nillable. This change allows a mission/project to enforce the inclusion of a value for <Science_Facets.wavelength_range> at the local governance level, even when no value is applicable.