### PR TITLE
Issue #19 CCB-262-Add_Supporting_Observationan_To_Primary_Result_Summ…

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Sat Aug 17 12:40:27 PDT 2019
+; Sat Aug 17 15:18:05 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Sat Aug 17 12:40:27 PDT 2019
+; Sat Aug 17 15:18:05 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -5587,7 +5587,7 @@
 	(multislot purpose
 ;+		(comment "The purpose attribute provides an indication of the primary purpose of the observations included.")
 		(type STRING)
-;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering" "Observation Geometry")
+;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering" "Observation Geometry" "Supporting Observation")
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot description

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Sat Aug 17 14:56:54 PDT 2019
+; Sat Aug 17 15:23:22 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -31218,7 +31218,8 @@
 		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-920488205]
 		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-438835660]
 		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-2042815962]
-		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-712232380])
+		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-712232380]
+		[pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1300673855])
 	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose")
 	(datatype [ASCII_Short_String_Collapsed])
 	(defaultUnitId "TBD_default_unit_id")
@@ -66787,6 +66788,14 @@
 	(usedIn [vm.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.-920488205])
 	(value "Engineering"))
 
+([pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1300673855] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1300673855])
+	(value "Supporting Observation"))
+
 ([pv.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1601548646] of  PermissibleValue
 
 	(beginDate "2009-06-09")
@@ -82429,7 +82438,7 @@
 ([vm.0001_NASA_PDS_1.pds.Information_Package_Component_Deep_Archive.pds.checksum_type.76158] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The value of the checksum is produced by the Message-Digest Algorithm (MD5) output of the MD5 Deep Package (see http://md5deep.sourceforge.net/).")
+	(description "The value of the checksum is produced by the Message-Digest Algorithm %28MD5%29 output of the MD5 Deep Package %28see http:%2F%2Fmd5deep.sourceforge.net%2F%29.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Instrument.pds.type.-1103122093] of  ValueMeaning
@@ -83444,6 +83453,12 @@
 
 	(beginDate "2009-06-09")
 	(description "Data collected about support systems and structures, which are ancillary to the primary measurements.")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1300673855] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "A science observation that was acquired to provide support for another science observation (e.g., a context image for a very high resolution observation, or an image intended to support an observation by a spectral imager).")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Primary_Result_Summary.pds.purpose.1601548646] of  ValueMeaning


### PR DESCRIPTION
…ary_purpose

Add the permissible value “Supporting Observation” as an enumerated value to <Primary_Result_Summary.purpose>. This change provides, for example, a means to indicate an image was taken to provide context for observations made by other instruments.