### PR TITLE
Issue #25 CCB-253-Add_Units_of_Force_as_a_unit_of_measure

### DIFF
--- a/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
+++ b/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
@@ -402,8 +402,10 @@
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Current</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Distance</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Energy</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
+  <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Force</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Frame_Rate</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Frequency</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
+  <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Gmass</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Length</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record>
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Mass</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Units_of_Misc</Field> <Field>1Mu</Field> <Field>#22</Field> <Field>pds</Field> <Field>pds</Field> </Record> 

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Sun Aug 18 16:24:57 PDT 2019
+; Mon Aug 19 10:00:54 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Sun Aug 18 16:24:56 PDT 2019
+; Mon Aug 19 10:00:54 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -11399,6 +11399,50 @@
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
 ;+		(value "eV" "keV" "MeV" "J")
+;+		(cardinality 1 1)
+		(create-accessor read-write)))
+
+(defclass Units_of_Gmass "Units_of_Gmass is a product of the universal gravitational constant and the mass of one specified body"
+	(is-a Unit_Of_Measure)
+	(role concrete)
+	(single-slot type
+;+		(comment "The type attribute provides a classification for the resource.")
+		(type STRING)
+;+		(value "Gmass")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot specified_unit_id
+;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
+		(type STRING)
+;+		(value "km**3s**-2")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot unit_id
+;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
+		(type STRING)
+;+		(value "km**3s**-2")
+;+		(cardinality 1 1)
+		(create-accessor read-write)))
+
+(defclass Units_of_Force "Units_of_Force is a magnitude of force."
+	(is-a Unit_Of_Measure)
+	(role concrete)
+	(single-slot type
+;+		(comment "The type attribute provides a classification for the resource.")
+		(type STRING)
+;+		(value "Force")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot specified_unit_id
+;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
+		(type STRING)
+;+		(value "N")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot unit_id
+;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
+		(type STRING)
+;+		(value "N")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Sun Aug 18 18:41:32 PDT 2019
+; Mon Aug 19 10:14:11 PDT 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -805,6 +805,8 @@
 		[EVD.0001_NASA_PDS_1.pds.UTF8_Short_String_Preserved.pds.xml_schema_base_type]
 		[EVD.0001_NASA_PDS_1.pds.UTF8_String.pds.minimum_characters]
 		[EVD.0001_NASA_PDS_1.pds.UTF8_String.pds.xml_schema_base_type]
+		[EVD.0001_NASA_PDS_1.pds.UTF8_Text_Collapsed.pds.minimum_characters]
+		[EVD.0001_NASA_PDS_1.pds.UTF8_Text_Collapsed.pds.xml_schema_base_type]
 		[NEVD.0001_NASA_PDS_1.pds.UTF8_Text_Preserved.pds.character_constraint]
 		[NEVD.0001_NASA_PDS_1.pds.UTF8_Text_Preserved.pds.maximum_characters]
 		[NEVD.0001_NASA_PDS_1.pds.UTF8_Text_Preserved.pds.maximum_value]
@@ -838,6 +840,9 @@
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.specified_unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Length.pds.specified_unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Length.pds.type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Length.pds.unit_id]
@@ -1056,14 +1061,15 @@
 		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.skos_relation_name]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.steward_id]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.title]
-		[EVD.0001_NASA_PDS_1.pds.UTF8_Text_Collapsed.pds.minimum_characters]
-		[EVD.0001_NASA_PDS_1.pds.UTF8_Text_Collapsed.pds.xml_schema_base_type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Current.pds.specified_unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Current.pds.type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Current.pds.unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Energy.pds.specified_unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Energy.pds.type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Energy.pds.unit_id]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.type]
+		[EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.specified_unit_id]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.type]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id]
@@ -12495,6 +12501,48 @@
 	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Energy.pds.unit_id])
 	(versionIdentifier "1.12"))
 
+([DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(versionIdentifier "1.12"))
+
+([DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(versionIdentifier "1.12"))
+
+([DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(versionIdentifier "1.12"))
+
 ([DE.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  DataElement
 
 	(administrationRecord [DD_1.12.0.0])
@@ -12577,6 +12625,48 @@
 	(steward [pds])
 	(submitter [Submitter_PDS])
 	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id])
+	(versionIdentifier "1.12"))
+
+([DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(versionIdentifier "1.12"))
+
+([DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(versionIdentifier "1.12"))
+
+([DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  DataElement
+
+	(administrationRecord [DD_1.12.0.0])
+	(dataIdentifier "DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id")
+	(expressedBy [DEC_TBD_classConcept])
+	(isNillable "false")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representing [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
+	(steward [pds])
+	(submitter [Submitter_PDS])
+	(terminologicalEntry [TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
 	(versionIdentifier "1.12"))
 
 ([DE.0001_NASA_PDS_1.pds.Units_of_Length.pds.specified_unit_id] of  DataElement
@@ -15684,6 +15774,12 @@
 		[DE.0001_NASA_PDS_1.pds.Units_of_Energy.pds.specified_unit_id]
 		[DE.0001_NASA_PDS_1.pds.Units_of_Energy.pds.type]
 		[DE.0001_NASA_PDS_1.pds.Units_of_Energy.pds.unit_id]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type]
+		[DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id]
 		[DE.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.specified_unit_id]
 		[DE.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.type]
 		[DE.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id]
@@ -20000,6 +20096,21 @@
 	(definitionText "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 	(isPreferred TRUE))
 
+([DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  Definition
+
+	(definitionText "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
+	(isPreferred TRUE))
+
+([DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  Definition
+
+	(definitionText "The type attribute provides a classification for the resource.")
+	(isPreferred TRUE))
+
+([DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  Definition
+
+	(definitionText "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
+	(isPreferred TRUE))
+
 ([DEF.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  Definition
 
 	(definitionText "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
@@ -20026,6 +20137,21 @@
 	(isPreferred TRUE))
 
 ([DEF.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id] of  Definition
+
+	(definitionText "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
+	(isPreferred TRUE))
+
+([DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  Definition
+
+	(definitionText "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
+	(isPreferred TRUE))
+
+([DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  Definition
+
+	(definitionText "The type attribute provides a classification for the resource.")
+	(isPreferred TRUE))
+
+([DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  Definition
 
 	(definitionText "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 	(isPreferred TRUE))
@@ -24960,6 +25086,21 @@
 	(designationName "unit_id")
 	(isPreferred TRUE))
 
+([DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  Designation
+
+	(designationName "specified_unit_id")
+	(isPreferred TRUE))
+
+([DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  Designation
+
+	(designationName "type")
+	(isPreferred TRUE))
+
+([DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  Designation
+
+	(designationName "unit_id")
+	(isPreferred TRUE))
+
 ([DES.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  Designation
 
 	(designationName "specified_unit_id")
@@ -24986,6 +25127,21 @@
 	(isPreferred TRUE))
 
 ([DES.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id] of  Designation
+
+	(designationName "unit_id")
+	(isPreferred TRUE))
+
+([DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  Designation
+
+	(designationName "specified_unit_id")
+	(isPreferred TRUE))
+
+([DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  Designation
+
+	(designationName "type")
+	(isPreferred TRUE))
+
+([DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  Designation
 
 	(designationName "unit_id")
 	(isPreferred TRUE))
@@ -32671,6 +32827,72 @@
 	(valueDomainFormat "TBD_format")
 	(versionIdentifier "1.12"))
 
+([EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id.78])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id")
+	(datatype [UTF8_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
+([EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.type.68065995])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.type")
+	(datatype [ASCII_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
+([EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id.78])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id")
+	(datatype [UTF8_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
 ([EVD.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  EnumeratedValueDomain
 
 	(administrationRecord [DD_1.12.0.0])
@@ -32796,6 +33018,72 @@
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
+([EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id.1375474215])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id")
+	(datatype [UTF8_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
+([EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type.68914107])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type")
+	(datatype [ASCII_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(representedBy2 [CD_Short_String])
+	(steward [Steward_PDS])
+	(submitter [Submitter_PDS])
+	(unitOfMeasure [TBD_unit_of_measure_type])
+	(valueDomainFormat "TBD_format")
+	(versionIdentifier "1.12"))
+
+([EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  EnumeratedValueDomain
+
+	(administrationRecord [DD_1.12.0.0])
+	(containedIn1 [pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id.1375474215])
+	(dataIdentifier "EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id")
+	(datatype [UTF8_Short_String_Collapsed])
+	(defaultUnitId "TBD_default_unit_id")
+	(maximumCharacterQuantity "TBD_maximum_characters")
+	(maximumValue "TBD_maximum_value")
+	(minimumCharacterQuantity "TBD_minimum_characters")
+	(minimumValue "TBD_minimum_value")
+	(pattern "TBD_pattern")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(representedBy [DE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
 	(representedBy2 [CD_Short_String])
 	(steward [Steward_PDS])
 	(submitter [Submitter_PDS])
@@ -57834,6 +58122,33 @@
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
 
+([PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.type")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
 ([PR.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  Property
 
 	(administrationRecord [DD_1.12.0.0])
@@ -57884,6 +58199,33 @@
 	(administrationRecord [DD_1.12.0.0])
 	(classOrder "1030")
 	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.12"))
+
+([PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  Property
+
+	(administrationRecord [DD_1.12.0.0])
+	(classOrder "9999")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.12"))
@@ -68966,6 +69308,30 @@
 	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Energy.pds.unit_id.77214])
 	(value "MeV"))
 
+([pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id.78] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id.78])
+	(value "N"))
+
+([pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.type.68065995] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.type.68065995])
+	(value "Force"))
+
+([pv.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id.78] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id.78])
+	(value "N"))
+
 ([pv.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id.-1644955318] of  PermissibleValue
 
 	(beginDate "2009-06-09")
@@ -69013,6 +69379,30 @@
 	(endDate "2019-12-31")
 	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id.2354])
 	(value "Hz"))
+
+([pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id.1375474215] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id.1375474215])
+	(value "km**3s**-2"))
+
+([pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type.68914107] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type.68914107])
+	(value "Gmass"))
+
+([pv.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id.1375474215] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id.1375474215])
+	(value "km**3s**-2"))
 
 ([pv.0001_NASA_PDS_1.pds.Units_of_Length.pds.specified_unit_id.109] of  PermissibleValue
 
@@ -76123,6 +76513,27 @@
 	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Energy.pds.unit_id])
 	(sectionLanguage [LI_English]))
 
+([TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id])
+	(sectionLanguage [LI_English]))
+
+([TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.type] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.type])
+	(sectionLanguage [LI_English]))
+
+([TE.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id])
+	(sectionLanguage [LI_English]))
+
 ([TE.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id] of  TerminologicalEntry
 
 	(administeredItemContext [NASA_PDS])
@@ -76163,6 +76574,27 @@
 	(administeredItemContext [NASA_PDS])
 	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id])
 	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id])
+	(sectionLanguage [LI_English]))
+
+([TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id])
+	(sectionLanguage [LI_English]))
+
+([TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type])
+	(sectionLanguage [LI_English]))
+
+([TE.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id] of  TerminologicalEntry
+
+	(administeredItemContext [NASA_PDS])
+	(definition [DEF.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
+	(designation [DES.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id])
 	(sectionLanguage [LI_English]))
 
 ([TE.0001_NASA_PDS_1.pds.Units_of_Length.pds.specified_unit_id] of  TerminologicalEntry
@@ -77534,6 +77966,13 @@
 		"eV"
 		"keV"))
 
+([Units_of_Force] of  UnitOfMeasure
+
+	(defaultUnitId "N")
+	(measureName "Units_of_Force")
+	(precision "TBD_precision")
+	(unitId "N"))
+
 ([Units_of_Frame_Rate] of  UnitOfMeasure
 
 	(defaultUnitId "frames%2Fs")
@@ -77547,6 +77986,13 @@
 	(measureName "Units_of_Frequency")
 	(precision "TBD_precision")
 	(unitId "Hz"))
+
+([Units_of_Gmass] of  UnitOfMeasure
+
+	(defaultUnitId "km**3s**-2")
+	(measureName "Units_of_Gmass")
+	(precision "TBD_precision")
+	(unitId "km**3s**-2"))
 
 ([Units_of_Length] of  UnitOfMeasure
 
@@ -85154,6 +85600,24 @@
 	(description "The abbreviated unit for megaelectronvolts in Units_of_Energy.")
 	(endDate "2019-12-31"))
 
+([vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.specified_unit_id.78] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "Units_of_Force maximum, minimum, and permissible values are given in the unit newton.")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.type.68065995] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "Units_of_Force is classified as being of type Force.")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Force.pds.unit_id.78] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "The abbreviated unit for newtons in Units_of_Force.")
+	(endDate "2019-12-31"))
+
 ([vm.0001_NASA_PDS_1.pds.Units_of_Frame_Rate.pds.specified_unit_id.-1644955318] of  ValueMeaning
 
 	(beginDate "2009-06-09")
@@ -85188,6 +85652,24 @@
 
 	(beginDate "2009-06-09")
 	(description "The abbreviated unit for Units_of_Frequency is Hz")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.specified_unit_id.1375474215] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "Units_of_Gmass maximum, minimum, and permissible values are given in the units km**3s**-2.")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.type.68914107] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "Units_of_Gmass gives the value of the product of the universal gravitational constant, G, and the mass of one specified body. The form is %28Units_of_Length%29**3%2F%28Units_of_Time%29**2")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Gmass.pds.unit_id.1375474215] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "Units_of_Gmass maximum, minimum, and permissible values are given in the units km**3s**-2.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Units_of_Length.pds.specified_unit_id.109] of  ValueMeaning


### PR DESCRIPTION
Add Units_of_Force as a unit_of_measure_type. This change is required in order to capture how hard the M2020 arm pre-load tool is pushing on the surface before beginning a drilling operation.