### PR TITLE
Issue #36 DOMConv Deprecation_FinalCleanup - DeprecatedDefn

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -27,6 +27,7 @@
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 package gov.nasa.pds.model.plugin; 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -82,7 +83,7 @@ public class DMDocument extends Object {
 	static String dataDirPath  = "TBD_dataDirPath";
 	static String outputDirPath = "./";
 
-	static String DMDocVersionId  = "1.18.1";
+	static String DMDocVersionId  = "1.19.1";
 //	static String XMLSchemaLabelBuildNum = "6a";
 	static String XMLSchemaLabelBuildNum;
 	
@@ -108,6 +109,8 @@ public class DMDocument extends Object {
 	// 1.10.1.0 - 1.16 - 1.16 - Build 8b
 	// 1.11.0.0 - 1.17 - 1.17 - Build 9a
 	// 1.12.0.0 - 1.18 - 1.18 - Build 9b
+	// 1.13.0.0 - 1.19 - 1.19 - Build 10a
+	// 1.14.0.0 - 1.20 - 1.20 - Build 10b
 	
 	// Actual    VID    MOD
 	// 1.0.0.0 - 1.0  - 1.0  - Build 3b
@@ -129,11 +132,13 @@ public class DMDocument extends Object {
 	// 1.10.1.0 - 1.16 - 1.16 - Build 8b
 	// 1.11.0.0 - 1.17 - 1.17 - Build 9a
 	// 1.12.0.0 - 1.18 - 1.18 - Build 9b
+	// 1.13.0.0 - 1.19 - 1.19 - Build 10a
+	// 1.14.0.0 - 1.20 - 1.20 - Build 10b
 	
 	// x.x.x.x - 1.0 - 1.n - Build nm - first version of product will always be 1.0
 	//									Modification history will continue with 1.n
 	                         
-	static String LDDToolVersionId  = "0.2.2.5";
+	static String LDDToolVersionId  = "0.2.2.6";
 	static String classVersionIdDefault = "1.0.0.0";
 //	static String LDDToolGeometry = "Geometry";
 	static boolean PDS4MergeFlag  = false;
@@ -284,7 +289,6 @@ public class DMDocument extends Object {
 		PDSOptionalFlag = false;
 		LDDToolFlag = false;
 		// Secondary LDD Models
-		LDDModelArr = new ArrayList <LDDParser> ();
 		LDDDOMModelArr = new ArrayList <LDDDOMParser> ();
 		LDDSchemaFileSortArr = new ArrayList <SchemaFileDefn> ();
 		LDDToolAnnotateDefinitionFlag = false;
@@ -1066,56 +1070,6 @@ public class DMDocument extends Object {
 		  }
 		  return buf.toString();
 		}
-	
-	/**
-	 *   get the disposition of a class (from Protege)
-	 */
-	static public PDSObjDefn getClassDisposition (PDSObjDefn lClass, String lClassName, boolean isFromProtege) {
-		// get disposition identifier - if isFromProtege, then the identifier is set else it is not since it is from an LDD.
-		String lDispId = lClass.subModelId + "." + registrationAuthorityIdentifierValue + "." + lClassName;
-		if (! isFromProtege) lDispId = "LDD_" + lDispId;
-		DispDefn lDispDefn = masterClassDispoMap2.get(lDispId);
-		if (lDispDefn != null) {
-			lClass.used = lDispDefn.used;
-			lClass.section = lDispDefn.section;
-			String lDisp = lDispDefn.disposition;
-			lClass.steward = lDispDefn.intSteward;
-			String lClassNameSpaceIdNC = lDispDefn.intNSId;
-			lClass.nameSpaceIdNC = lClassNameSpaceIdNC;
-			lClass.nameSpaceId = lClassNameSpaceIdNC + ":";
-			
-			// if from protege, the identifier needs to be set; if from LDD it cannot be set here.
-			if (isFromProtege) lClass.identifier = InfoModel.getClassIdentifier(lClassNameSpaceIdNC, lClassName);
-			lClass.isMasterClass = true;
-			if (lDisp.indexOf("V") > -1) {
-				lClass.isVacuous = true;
-			}
-			if (lDisp.indexOf("S") > -1) {
-				lClass.isSchema1Class = true;
-			}
-			if (lDisp.indexOf("R") > -1) {
-				lClass.isRegistryClass = true;
-			}
-			if (lDisp.indexOf("T") > -1) {
-				lClass.isTDO = true;
-			}
-			if (lDisp.indexOf("d") > -1) {
-				lClass.isDataType = true;
-			}
-			if (lDisp.indexOf("u") > -1) {
-				lClass.isUnitOfMeasure = true;
-			}
-/*			if (lDisp.indexOf("E") > -1) {
-				lClass.versionId = "1.1.0.0";
-			} else if (lDisp.indexOf("D") > -1) {
-				lClass.versionId = "1.2.0.0";
-			} else if (lDisp.indexOf("F") > -1) {
-				lClass.versionId = "1.n.0.0";
-			} */
-			return lClass;
-		}
-		return null;
-	}	
 	
 	/**
 	 *   get the disposition of a class (from Protege)

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -146,20 +146,11 @@ public abstract class DOMInfoModel extends Object {
 	static TreeMap <String, String> decID2DECTitleMap;
 	static TreeMap <String, String> decTitle2DECIDMap;
 	
-	static PDSObjDefn LDDToolSingletonClass; // Class for LDD singleton attributes (Discipline or Mission)
-	// 77775
-//	static DOMClass LDDToolSingletonDOMClass; // Class for LDD singleton attributes (Discipline or Mission)
-	
 	// values and value meaning
 	static TreeMap <String, PermValueDefn> masterValueMeaningMap;
 
 	// Attribute Namespace Resolution Map
 	static TreeMap <String, String> attrNamespaceResolutionMap;
-	
-	// Local Classes	
-	ArrayList <PDSObjDefn> objArr;
-	HashMap <String, PDSObjDefn> objDict;
-	HashMap <String, AttrDefn> attrDict;
 	
 //  Parsed Classes, Props, and Attributes
 	static ArrayList <DOMClass> parsedClassArr;
@@ -874,52 +865,6 @@ public abstract class DOMInfoModel extends Object {
 		return null;
 	}
 	
-	/**
-	*  Return all attributes in a class - recurse down through all associations.
-	*/
-	public static ArrayList <AttrDefn> getAllAttrRecurse (ArrayList <AttrDefn> lAttrArr, ArrayList <PDSObjDefn> visitedClass, PDSObjDefn lClass) {
-		//	get all local attributes
-		for (Iterator<AttrDefn> i = lClass.ownedAttribute.iterator(); i.hasNext();) {
-			AttrDefn lAttr = (AttrDefn) i.next();
-			if (! lAttrArr.contains(lAttr)) {
-				lAttrArr.add(lAttr);
-			}
-		} 	
-		
-		//	get all inherited attributes
-		for (Iterator<AttrDefn> i = lClass.inheritedAttribute.iterator(); i.hasNext();) {
-			AttrDefn lAttr = (AttrDefn) i.next();
-			if (! lAttrArr.contains(lAttr)) {
-				lAttrArr.add(lAttr);
-			}
-		} 	
-		
-		//get all local associations
-		for (Iterator<AttrDefn> i = lClass.ownedAssociation.iterator(); i.hasNext();) {
-			AttrDefn lAssoc = (AttrDefn) i.next();
-			for (Iterator<PDSObjDefn> j = lAssoc.valClassArr.iterator(); j.hasNext();) {
-				PDSObjDefn lCompClass = j.next();
-				if (! visitedClass.contains(lCompClass)) {
-					visitedClass.add(lCompClass);
-					getAllAttrRecurse (lAttrArr, visitedClass, lCompClass);
-				}
-			}
-		}
-		
-		//get all inherited associations
-		for (Iterator<AttrDefn> i = lClass.inheritedAssociation.iterator(); i.hasNext();) {
-			AttrDefn lAssoc = (AttrDefn) i.next();
-			for (Iterator<PDSObjDefn> j = lAssoc.valClassArr.iterator(); j.hasNext();) {
-				PDSObjDefn lCompClass = j.next();
-				if (! visitedClass.contains(lCompClass)) {
-					visitedClass.add(lCompClass);
-					getAllAttrRecurse (lAttrArr, visitedClass, lCompClass);
-				}
-			}
-		}
-		return lAttrArr;
-	}
-		
 	public static ArrayList <String> getAllRefAssocType (ArrayList <AttrDefn> lAttrArr) {		
 		ArrayList <String> lRefTypeArr = new ArrayList <String> ();
 		for (Iterator<AttrDefn> i = lAttrArr.iterator(); i.hasNext();) {
@@ -1156,19 +1101,6 @@ public abstract class DOMInfoModel extends Object {
 	}
 	
 //======================= Master Sorts =============================================================================
-	
-	static public ArrayList <AttrDefn> getSortedAlphaClassAssocAttrArr (PDSObjDefn lClass) {
-		TreeMap <String, AttrDefn> lAttrMapOrdered = new TreeMap <String, AttrDefn> ();
-		ArrayList<AttrDefn> lAttrArr = new ArrayList<AttrDefn>();
-		lAttrArr.addAll(lClass.ownedAttribute);
-		lAttrArr.addAll(lClass.inheritedAttribute);
-		for (Iterator<AttrDefn> i = lAttrArr.iterator(); i.hasNext();) {
-			AttrDefn lAttr = (AttrDefn) i.next();
-			lAttrMapOrdered.put(lAttr.title, lAttr);
-		}
-		ArrayList<AttrDefn> lAttrArrOrdered = new ArrayList<AttrDefn> (lAttrMapOrdered.values()); 
-		return lAttrArrOrdered;
-	}
 	
 	static public ArrayList <DOMAssocClassDefn> getSortedAlphaClassAssocClassArr (DOMClass lClass) {
 		TreeMap <String, DOMAssocClassDefn> lAssocClassGroupMap = new TreeMap <String, DOMAssocClassDefn> ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DeprecatedDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DeprecatedDefn.java
@@ -27,6 +27,7 @@
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
 package gov.nasa.pds.model.plugin; 
 public class DeprecatedDefn {
 	String identifier;
@@ -52,16 +53,16 @@ public class DeprecatedDefn {
 		isAttribute = false;
 		isUnitId = lIsUnitId;
 		if (value.compareTo("") != 0) {
-			identifier = InfoModel.getAttrIdentifier(lClassNameSpaceIdNC, lClassName, lAttrNameSpaceIdNC, lAttrName);
+			identifier = DOMInfoModel.getAttrIdentifier(lClassNameSpaceIdNC, lClassName, lAttrNameSpaceIdNC, lAttrName);
 			isValue = true;
 			isAttribute = true;
 			context = classNameSpaceIdNC + ":" + lClassName;
 		} else if (lAttrName.compareTo("") != 0) {
-			identifier = InfoModel.getAttrIdentifier(lClassNameSpaceIdNC, lClassName, lAttrNameSpaceIdNC, lAttrName);
+			identifier = DOMInfoModel.getAttrIdentifier(lClassNameSpaceIdNC, lClassName, lAttrNameSpaceIdNC, lAttrName);
 			isAttribute = true;
 			context = classNameSpaceIdNC + ":" + lClassName + "/" + lAttrNameSpaceIdNC + ":" + lAttrName;
 		} else {
-			identifier = InfoModel.getClassIdentifier(lClassNameSpaceIdNC, lClassName);
+			identifier = DOMInfoModel.getClassIdentifier(lClassNameSpaceIdNC, lClassName);
 			context = classNameSpaceIdNC + ":" + lClassName;
 		}
 	} 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -396,8 +396,6 @@ public class GetDOMModel extends Object {
 		}
 		
 		// 035 - generate the schematron rules (does not include custom rules)
-//		GenSchematronRules genSchematronRules = new GenSchematronRules ();
-//		genSchematronRules.genSchematronRules();
 		GenDOMRules lGenDOMRules = new GenDOMRules ();
 		lGenDOMRules.genSchematronRules();
 					

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -819,14 +819,6 @@ class MasterDOMInfoModel extends DOMInfoModel{
 		return false;
 	}
 	
-	// clone an array list
-	static public ArrayList <DOMClass> clonePDSObjDefnArrayList (ArrayList <DOMClass> lArrayList) {
-		ArrayList <DOMClass> newArrayList = new ArrayList <DOMClass> ();
-		newArrayList.addAll(lArrayList);								
-		return newArrayList;
-	}	
-	
-	
 	// 014 - Get the subClass array
 	public void getSubClasses () {
 		for (Iterator<DOMClass> i = masterDOMClassArr.iterator(); i.hasNext();) {			// get the target class
@@ -1452,42 +1444,6 @@ class MasterDOMInfoModel extends DOMInfoModel{
 				}
 			}
 			return;
-		}
-		
-		static public AttrDefn getPossibleRestrictedAttribute (AttrDefn lAttr, PDSObjDefn lSuperClass) {
-			//	find the attribute by title in the super class.
-
-			for (Iterator<AttrDefn> i = lSuperClass.ownedAttribute.iterator(); i.hasNext();) {
-				AttrDefn lSuperAttr = (AttrDefn) i.next();
-				if ((lSuperAttr.title.compareTo(lAttr.title) == 0)) {
-					return lSuperAttr;
-				}
-			}
-			for (Iterator<AttrDefn> i = lSuperClass.inheritedAttribute.iterator(); i.hasNext();) {
-				AttrDefn lSuperAttr = (AttrDefn) i.next();
-				if ((lSuperAttr.title.compareTo(lAttr.title) == 0)) {
-					return lSuperAttr;
-				}
-			}
-			return null;
-		}
-		
-		static public AttrDefn getPossibleRestrictedAssociation (AttrDefn lAttr, PDSObjDefn lSuperClass) {
-			//	find the attribute by title in the super class.
-
-			for (Iterator<AttrDefn> i = lSuperClass.ownedAssociation.iterator(); i.hasNext();) {
-				AttrDefn lSuperAttr = (AttrDefn) i.next();
-				if ((lSuperAttr.title.compareTo(lAttr.title) == 0)) {
-					return lSuperAttr;
-				}
-			}
-			for (Iterator<AttrDefn> i = lSuperClass.inheritedAssociation.iterator(); i.hasNext();) {
-				AttrDefn lSuperAttr = (AttrDefn) i.next();
-				if ((lSuperAttr.title.compareTo(lAttr.title) == 0)) {
-					return lSuperAttr;
-				}
-			}
-			return null;
 		}
 		
 		public void dumpClassVersionIds () {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XMLDocParserDomMDPTNConfig.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XMLDocParserDomMDPTNConfig.java
@@ -54,7 +54,6 @@ public class XMLDocParserDomMDPTNConfig extends Object
 	
 	//No generics
 	Document dom;
-	AttrDefn lAttrMaster;				
 	String lFullName;				
 	String lLastModificationDateTime;				
 //	String lPds4MergeFlag;				


### PR DESCRIPTION
IMTool/LDDTool Conversion from MOF to DOM model; Final cleanup; Focus on DeprecatedDefn and similar methods.

1) XMLDocParserDomMDPTNConfig.java 57  AttrDefn
   Deprecate - 	AttrDefn lAttrMaster;

2) DeprecatedDefn
   InfoModel -> DOMInfoModel

3) WriteSchematronRulesPins - Validated deprecate
   deprecate - Wrote MODEL_RULES file. Initated Upper_Model standard rules in .pins file

4) GetDOMModel
   deprecate GenSchematronRules genSchematronRules = new GenSchematronRules ();
   deprecate genSchematronRules.genSchematronRules();

5) MasterDOMInfoModel.java 1457, 1475 AttrDefn, PDSObjDefn
   deprecate getPossibleRestrictedAttribute
   deprecate getPossibleRestrictedAssociation
   deprecate clonePDSObjDefnArrayList

6) DOMInfoModel.java 149, 154, 160, 161, PermValueDefn, PDSObjDefn - Partially Done. - Wait on PermValueDefn
   deprecate static PDSObjDefn LDDToolSingletonClass;
   convert static TreeMap <String, PermValueDefn> masterValueMeaningMap; - Not Done.
   deprecate ArrayList <PDSObjDefn> objArr;
   deprecate getSortedAlphaClassAssocAttrArr
   deprecate getAllAttrRecurse
   deprecate getPossibleRestrictedAttribute
   deprecate getPossibleRestrictedAssociation
   deprecate clonePDSObjDefnArrayList

7) DMDocument - Partially Done; Too many dependencies in MOF modules.
   Deprecate LDDModelArr = new ArrayList <LDDParser> ();
   Deprecate static public PDSObjDefn getClassDisposition
   Deprecate static PDSObjDefn LDDToolSingletonClass = null - Leave until after deprecation; Used in many MOF classes
   Deprecate static MasterInfoModel masterInfoModel; - Leave until after deprecation; Used in many MOF classes