### PR TITLE
Issue #81 LDDTool_XMLSchema_Fix_Null_In_Import_Cleanup

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -521,6 +521,7 @@ public class DMDocument extends Object {
 			ExportModels lExportModels = new ExportModels ();
 			lExportModels.writeAllArtifacts (exportDOMFlag, exportMOFFlag);
 		}
+		System.out.println(">>info    - Exit");
 	}
 	
 /**********************************************************************************************************

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMDataType.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMDataType.java
@@ -170,7 +170,6 @@ public class DOMDataType extends ISOClassOAIS11179 {
 	// new - not currently being used - needs testing
 	public void setDataTypeAttrs (DOMClass lClass) {
 		this.setIdentifier (DMDocument.masterNameSpaceIdNCLC, lClass.title);
-		this.nsTitle = DMDocument.masterNameSpaceIdNCLC + "." + lClass.title;
 		this.title =  lClass.title;
 		this.nameSpaceIdNC = lClass.nameSpaceIdNC;
 		this.type = lClass.title;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -326,12 +326,14 @@ public class LDDDOMParser extends Object
 		lComment = getTextValue(docEle,"comment");
 		if (lComment == null) lComment = "TBD_comment";
 		
-		// get namespace
+		// get namespace_id from Ingest_LDD
 		String lNameSpaceIdNC = getTextValue(docEle,"namespace_id");
 		if (lNameSpaceIdNC == null) lNameSpaceIdNC = "TBD";
 		
+		// find namespace_id in "all" schemaFiles (from config.properties) 
 		SchemaFileDefn lConfigSchemaFileDefn = DMDocument.masterAllSchemaFileSortMap.get(lNameSpaceIdNC);
 		if (lConfigSchemaFileDefn == null) {
+			// default to pds if not found
 			lConfigSchemaFileDefn = DMDocument.masterPDSSchemaFileDefn;
 			System.out.println("   WARNING  Init: " + " - Config.Properties Namespace Id Not Found:" + lNameSpaceIdNC);
 		} else {
@@ -339,8 +341,8 @@ public class LDDDOMParser extends Object
 		}
 		System.out.println("   INFO     Init: " + " - Config.Properties Namespace Id Using:" + lConfigSchemaFileDefn.identifier);
 		
-		// finally set namespace id and add to LDDSchemaFileSortMap
-		lSchemaFileDefn.setNameSpaceIds(lNameSpaceIdNC);
+		// finally set namespace id and add this LDD to LDDSchemaFileSortMap
+		lSchemaFileDefn.setNameSpaceIds(lNameSpaceIdNC); // all variations
 		DMDocument.LDDSchemaFileSortMap.put(lSchemaFileDefn.nameSpaceIdNCLC, lSchemaFileDefn);
 		lSchemaFileDefn.setRegAuthority (lConfigSchemaFileDefn);
 		
@@ -361,7 +363,7 @@ public class LDDDOMParser extends Object
 		if (! (lLDDVersionId == null || (lLDDVersionId.indexOf("TBD") == 0))) {
 			lSchemaFileDefn.versionId = lLDDVersionId;
 		}
-		lSchemaFileDefn.setVersionIds();
+		lSchemaFileDefn.setVersionIds(); // set variations of versions and all filenames
 		
 		String lStewardId = getTextValue(docEle,"steward_id");
 		if ( !(lStewardId == null || (lStewardId.indexOf("TBD") == 0))) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -699,12 +699,9 @@ class MasterDOMInfoModel extends DOMInfoModel{
 									DOMAttr lParentAttr = (DOMAttr) lChildProp.hasDOMObject;
 //									System.out.println("                            lParentAttr.identifier:" + lParentAttr.identifier);
 									testTrue = isRestrictedAttribute (true, lChildAttr, lParentAttr);
-									if (testTrue) {
-//										System.out.println("                            ***isARestriction*** lParentAttr.identifier:" + lParentAttr.identifier);
-										lClass.isARestriction = true;
-									}
 								}
 							}
+							if (testTrue) lClass.isARestriction = true;
 						}
 					}
 				}
@@ -726,8 +723,8 @@ class MasterDOMInfoModel extends DOMInfoModel{
 							for (Iterator <DOMProp> k = lParentClass.ownedAssocArr.iterator(); k.hasNext();) {
 								DOMProp lParentProp = (DOMProp) k.next();
 								testTrue = isRestrictedProp (false, lChildProp, lParentProp);
-								if (testTrue) lClass.isARestriction = true;
 							}
+							if (testTrue) lClass.isARestriction = true;
 						}
 					}
 				}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -234,7 +234,9 @@ class WriteDOMSchematron extends Object {
 						lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 						lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
 					} else {
-		    			System.out.println(">>error    - config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
+						lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
+						lNameSpaceURL = DMDocument.masterPDSSchemaFileDefn.nameSpaceURL;
+		    			System.out.println(">>warning  - config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
 					}
 				}
 				prSchematron.println("  <sch:ns uri=\"" + lNameSpaceURL + lNameSpaceIdNC + "/v" + lVersionNSId + "\" prefix=\"" + lNameSpaceIdNC + "\"/>");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -273,7 +273,6 @@ class XML4LabelSchemaDOM extends Object {
 			if (DMDocument.LDDToolFlag) {
 				for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 					String lNameSpaceIdNC = (String) i.next();
-					System.out.println("debug writeXMLSchemaFileHeader lNameSpaceIdNC:" +lNameSpaceIdNC);
 					String lVersionNSId = "TBD_lVersionNSId";
 					String lNameSpaceURL = "TBD_lNameSpaceURL";
 					
@@ -290,7 +289,9 @@ class XML4LabelSchemaDOM extends Object {
 							lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 							lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
 						} else {
-			    			System.out.println(">>error    - config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
+							lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
+							lNameSpaceURL = DMDocument.masterPDSSchemaFileDefn.nameSpaceURL;
+			    			System.out.println(">>warning  - config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
 						}
 					}
 					prXML.println("    xmlns:" + lNameSpaceIdNC + "=\"" + lNameSpaceURL + lNameSpaceIdNC + "/v" + lVersionNSId + "\"");


### PR DESCRIPTION
LDDTool general cleanup
	MasterDOMInfoModel - move test on testTrue outside of loop
	DOMDataType - setting this.nsTitle is not needed since it is set by this.setIdentifier
	DMDocument - added "exit" message
	XML4LabelSchemaDOM - get info for XML schema namespace declaration - add pds (common) as default
	WriteDOMSchematron - get info for XML schema namespace declaration - add pds (common) as default
	LDDDOMParser - added helpful comments.