### PR TITLE
CCB-138 Fix mismatch between object types in <Observing_System_Component> class

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1110,10 +1110,17 @@ public class DMDocument extends Object {
 //		deprecatedObjects2.add(new DeprecatedDefn ("Product_Context.Airborne.type", "pds", "Airborne", "pds", "type", "Suborbital Rocket", false));
 
 		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Airborne", false));
-//		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Aircraft", false));
-//		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Balloon", false));
-//		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Suborbital Rocket", false));
-
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Aircraft", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Balloon", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Suborbital Rocket", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Computer", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Facility", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Laboratory", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Naked Eye", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Observatory", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Spacecraft", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Observing_System_Component.type", "pds", "Observing_System_Component", "pds", "type", "Artificial Illumination", false));
+		
 		deprecatedObjects2.add(new DeprecatedDefn ("Internal_Reference.reference_type", "pds", "Internal_Reference", "pds", "reference_type", "is_airborne", false));
 		deprecatedObjects2.add(new DeprecatedDefn ("Bundle_Member_Entry.reference_type", "pds", "Bundle_Member_Entry", "pds", "reference_type", "bundle_has_member_collection", false));
 

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Dec 04 10:56:02 PST 2019
+; Thu Dec 05 16:22:15 PST 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Dec 04 10:56:01 PST 2019
+; Thu Dec 05 16:22:15 PST 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -10048,7 +10048,7 @@
 	(single-slot type
 ;+		(comment "The type attribute classifies the observing system component according to its function.")
 		(type STRING)
-;+		(value "Naked Eye" "Laboratory" "Observatory" "Telescope" "Instrument" "Literature Search" "Spacecraft" "Artificial Illumination" "Facility" "Balloon" "Airborne" "Aircraft" "Suborbital Rocket" "Computer")
+;+		(value "Naked Eye" "Laboratory" "Observatory" "Telescope" "Instrument" "Literature Search" "Spacecraft" "Artificial Illumination" "Facility" "Balloon" "Airborne" "Aircraft" "Suborbital Rocket" "Computer" "Host")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot description

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Wed Dec 04 11:42:33 PST 2019
+; Thu Dec 05 16:27:40 PST 2019
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -789,6 +789,8 @@
 		[NEVD.0001_NASA_PDS_1.pds.Target_PDS3.pds.target_type]
 		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry.pds.language]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry.pds.name]
+		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry.pds.skos_relation_name]
+		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.skos_relation_name]
 		[NEVD.0001_NASA_PDS_1.pds.Time_Coordinates.pds.local_mean_solar_time]
 		[NEVD.0001_NASA_PDS_1.pds.Time_Coordinates.pds.local_true_solar_time]
 		[NEVD.0001_NASA_PDS_1.pds.UTF8_Short_String_Collapsed.pds.character_constraint]
@@ -1053,7 +1055,6 @@
 		[EVD.0001_NASA_PDS_1.pds.Stream_Text.pds.parsing_standard_id]
 		[NEVD.0001_NASA_PDS_1.pds.Telescope.pds.coordinate_source]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry.pds.instance_id]
-		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry.pds.skos_relation_name]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.description]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.identifier]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.instance_id]
@@ -1062,7 +1063,6 @@
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.namespace_id]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.referenced_identifier]
 		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.registration_authority]
-		[EVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.skos_relation_name]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.steward_id]
 		[NEVD.0001_NASA_PDS_1.pds.Terminological_Entry_SKOS.pds.title]
 		[EVD.0001_NASA_PDS_1.pds.Units_of_Current.pds.specified_unit_id]
@@ -31268,6 +31268,7 @@
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.1325796367]
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.-534518981]
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.565760707]
+		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.2255304]
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.-906018809]
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.802704339]
 		[pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.-1149257897]
@@ -66946,6 +66947,14 @@
 	(usedIn [vm.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.1790220026])
 	(value "Observatory"))
 
+([pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.2255304] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.2255304])
+	(value "Host"))
+
 ([pv.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.565760707] of  PermissibleValue
 
 	(beginDate "2009-06-09")
@@ -71083,9 +71092,6 @@
 	(measureName "TBD_unit_of_measure_type")
 	(precision "TBD_precision")
 	(unitId "TBD_unitId"))
-
-([TBD_value_type] of  %3AUNDEFINED
-)
 
 ([TE.0001_NASA_PDS_1.pds.Agency.pds.description] of  TerminologicalEntry
 
@@ -83955,6 +83961,12 @@
 
 	(beginDate "2009-06-09")
 	(description "The observing system component is an observatory")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.2255304] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "The observing system component is a host or a member in a chain of hosts that ultimately contains an instrument that collects data.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Observing_System_Component.pds.type.565760707] of  ValueMeaning


### PR DESCRIPTION
The list of valid values for the <type> attribute in the <Observing_System_Component> class should be reduced to: Instrument, Host, Literature Search and Telescope. All other existing values should be deprecated.

Resolves #103
Refs CCB-138