### PR TITLE
LDDTool aborts on short filename

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -238,14 +238,14 @@ class XML4LabelSchemaDOM extends Object {
 		if (DMDocument.LDDToolFlag) {
 			prXML.println("  <!--                                                                           -->");
 			prXML.println("  <!--               Dictionary Stack                                            -->");
-			String lEntry = DMDocument.masterPDSSchemaFileDefn.ont_version_id + " - " + DMDocument.masterPDSSchemaFileDefn.nameSpaceId + " - " + DMDocument.masterPDSSchemaFileDefn.lddName + " - " + DMDocument.masterPDSSchemaFileDefn.sourceFileName + "                                   ";
+			String lSpaces73 = "                                                                         ";
+			String lEntry = DMDocument.masterPDSSchemaFileDefn.ont_version_id + " - " + DMDocument.masterPDSSchemaFileDefn.nameSpaceId + " - " + DMDocument.masterPDSSchemaFileDefn.lddName + " - " + DMDocument.masterPDSSchemaFileDefn.sourceFileName + lSpaces73;
 			lEntry = lEntry.substring(0, 73);
 			prXML.println("  <!-- " + lEntry + " -->");
 
 			for (Iterator <SchemaFileDefn> i = DMDocument.LDDSchemaFileSortArr.iterator(); i.hasNext();) {
 				SchemaFileDefn lFileInfo = (SchemaFileDefn) i.next();
-//				lEntry = lFileInfo.sourceFileName + " - " + lFileInfo.ont_version_id;
-				lEntry = lFileInfo.ont_version_id + " - " + lFileInfo.nameSpaceId + " - " + lFileInfo.lddName + " - " + lFileInfo.sourceFileName + "                                   ";
+				lEntry = lFileInfo.ont_version_id + " - " + lFileInfo.nameSpaceId + " - " + lFileInfo.lddName + " - " + lFileInfo.sourceFileName + lSpaces73;
 				lEntry = lEntry.substring(0, 73);
 				prXML.println("  <!-- " + lEntry + " -->");
 			}


### PR DESCRIPTION
Susie Slavney reported that LDDTool aborted when using a short filename for the Ingest_LDD file. The problem was in writing the Dictionary Stack to the XML Schema document. All stack entries are truncated to 73 characters. In this case the entry was less than 73 characters.

Resolves #111