### PR TITLE
Update tool versioning to move to config file

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -83,7 +83,7 @@ public class DMDocument extends Object {
 	static String dataDirPath  = "TBD_dataDirPath";
 	static String outputDirPath = "./";
 
-	static String DMDocVersionId  = "10.2.0";
+	static String DMDocVersionId  = "0.0.0";
 //	static String XMLSchemaLabelBuildNum = "6a";
 	static String XMLSchemaLabelBuildNum;
 	
@@ -120,7 +120,7 @@ public class DMDocument extends Object {
 	// x.x.x.x - 1.0 - 1.n - Build nm - first version of product will always be 1.0
 	//									Modification history will continue with 1.n
 	                         
-	static String LDDToolVersionId  = "10.2.1";
+	static String LDDToolVersionId  = "0.0.0";
 	static String buildIMVersionId = "1.14.0.0";
 	static String classVersionIdDefault = "1.0.0.0";
 //	static String LDDToolGeometry = "Geometry";
@@ -348,7 +348,7 @@ public class DMDocument extends Object {
 		String configInputFile = dataDirPath + "config.properties";
 		String configInputStr;
     	File configFile = new File(configInputFile); 
-    	try {
+    	try { 
     	    FileReader reader = new FileReader(configFile);
 //    	    Properties props = new Properties();
     	    props.load(reader);
@@ -383,6 +383,11 @@ public class DMDocument extends Object {
     	    configInputStr= props.getProperty("mastModelId");
     	    if (configInputStr != null) mastModelId = configInputStr;
     	    
+    	    configInputStr= props.getProperty("toolVersionId");
+            if (configInputStr != null) {
+                DMDocVersionId = LDDToolVersionId = configInputStr;
+            }
+
     	    reader.close();
     	} catch (FileNotFoundException ex) {
     	    // file does not exist

--- a/model-lddtool/src/main/assembly/tar-assembly.xml
+++ b/model-lddtool/src/main/assembly/tar-assembly.xml
@@ -103,6 +103,7 @@
       <includes>
         <include>**/*</include>
       </includes>
+      <filtered>true</filtered>
     </fileSet>
     <fileSet>
       <directory>target/site</directory>

--- a/model-lddtool/src/main/assembly/zip-assembly.xml
+++ b/model-lddtool/src/main/assembly/zip-assembly.xml
@@ -103,6 +103,7 @@
       <includes>
         <include>**/*</include>
       </includes>
+      <filtered>true</filtered>
     </fileSet>
     <fileSet>
       <directory>target/site</directory>

--- a/model-ontology/src/ontology/Data/config.properties
+++ b/model-ontology/src/ontology/Data/config.properties
@@ -1,5 +1,6 @@
 #DMDOC settings
 #Thu Sep 22 12:00:00 PDT 2019
+toolVersionId=${project.version}
 infoModelVersionId=1.14.0.0
 schemaLabelVersionId=1.20
 imSpecDocTitle=PDS4 Information Model Specification


### PR DESCRIPTION
Similar to other config information and how we tend to handle versioning in
other tools, moved the software version to a config file that uses the Maven
version automatically.

One less thing we have to change at build time.

Resolves #124