### PR TITLE
Add reference_types for Product_Ancillary

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -349,7 +349,7 @@ public class DMDocument extends Object {
 		String configInputFile = dataDirPath + "config.properties";
 		String configInputStr;
     	File configFile = new File(configInputFile); 
-    	try { 
+    	try {
     	    FileReader reader = new FileReader(configFile);
 //    	    Properties props = new Properties();
     	    props.load(reader);
@@ -389,11 +389,11 @@ public class DMDocument extends Object {
                 DMDocVersionId = LDDToolVersionId = configInputStr;
             }
             
-            configInputStr= props.getProperty("buildDate");
+          configInputStr= props.getProperty("buildDate");
             if (configInputStr != null) {
                 buildDate = configInputStr;
             }
-
+    	    
     	    reader.close();
     	} catch (FileNotFoundException ex) {
     	    // file does not exist
@@ -516,6 +516,7 @@ public class DMDocument extends Object {
 			ExportModels lExportModels = new ExportModels ();
 			lExportModels.writeAllArtifacts (exportDOMFlag, exportMOFFlag);
 		}
+		if (debugFlag) System.out.println (">>info    - Next UID: " + DOMInfoModel.getNextUId());
 		System.out.println(">>info    - Exit");
 	}
 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
@@ -129,6 +129,10 @@ class GetValueMeanings extends Object{
 
 		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Reference_List/pds:Internal_Reference.reference_type.ancillary_to_data", "ancillary_to_data", "The ancillary product is associated to a data product"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
+		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Context_Area/pds:Investigation_Area/pds:Internal_Reference.reference_type.ancillary_to_investigation", "ancillary_to_investigation", "The ancillary data product is associated to an investigation"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
+		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.ancillary_to_target", "ancillary_to_target", "The ancillary data product is associated to a target"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
+		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Reference_List/pds:Internal_Reference.reference_type.ancillary_to_document", "ancillary_to_document", "The ancillary data product is associated to a document"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
 		lPVD = new PermValueDefn ("pds:Product_Observational/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_geometry", "data_to_geometry", "The data product is associated to geometry"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Observational/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_spice_kernel", "data_to_spice_kernel", "The data product is associated to spice kernel(s)"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Observational/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_thumbnail", "data_to_thumbnail", "The data product is associated to a thumbnail"); masterValueMeaningMap.put(lPVD.identifier, lPVD);

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Dec 26 21:12:59 PST 2019
+; Mon Feb 10 15:51:29 PST 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1098,6 +1098,56 @@
 		"package_has_product"
 		"package_compiled_from_package"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3AInvestigation_Area%2Fpds%3AInternal_Reference.100004503] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3AInvestigation_Area%2Fpds%3AInternal_Reference.100004503.101])
+	(identifier "pds:Product_Ancillary/pds:Context_Area/pds:Investigation_Area/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Ancillary/pds:Context_Area/pds:Investigation_Area/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3AInvestigation_Area%2Fpds%3AInternal_Reference.100004503.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('xxx')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "ancillary_to_investigation"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004504] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004504.101])
+	(identifier "pds:Product_Ancillary/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Ancillary/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004504.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('xxx')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "ancillary_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Ancillary%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100002528] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -1121,7 +1171,9 @@
 	(attrTitle "reference_type")
 	(identifier "reference_type")
 	(specMesg "TBD")
-	(testValArr "ancillary_to_data"))
+	(testValArr
+		"ancillary_to_data"
+		"ancillary_to_document"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100002529] of  Schematron_Rule
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Dec 26 21:12:59 PST 2019
+; Mon Feb 10 15:51:29 PST 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")


### PR DESCRIPTION
Add reference_types for Product_Ancillary

1. For attribute:	Product_Ancillary/Context_Area/Investigation_Area/Internal_Reference/reference_type
			ancillary_to_investigation - The ancillary data product is associated to an investigation

2. For attribute: Product_Ancillary/Context_Area/Target_Identification/Internal_reference/reference_type
			ancillary_to_target - The ancillary data product is associated to a target

3. For attribute: Product_Ancillary/Reference_List/Internal_Reference/reference_type
			ancillary_to_document - The ancillary data product is associated to a document

Resolves #133
Refs CCB-271