### PR TITLE
Add attribute dictionary_type to Ingest_LDD - Remove -M Option

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -272,7 +272,7 @@ public class DMDocument extends Object {
 		LDDDOMModelArr = new ArrayList <LDDDOMParser> ();
 		LDDSchemaFileSortArr = new ArrayList <SchemaFileDefn> ();
 		LDDToolAnnotateDefinitionFlag = false;
-		LDDToolMissionGovernanceFlag = false;
+//		LDDToolMissionGovernanceFlag = false;
 
 		// get dates
 		rTodaysDate = new Date();
@@ -576,9 +576,9 @@ public class DMDocument extends Object {
 				if (lArg.indexOf('d') > -1) {
 					LDDToolAnnotateDefinitionFlag = true;
 				}
-				if (lArg.indexOf('M') > -1) {
-					LDDToolMissionGovernanceFlag = true;
-				}
+//				if (lArg.indexOf('M') > -1) {
+//					LDDToolMissionGovernanceFlag = true;
+//				}
 				if (lArg.indexOf('m') > -1) {
 					PDS4MergeFlag = true;
 				}
@@ -644,7 +644,7 @@ public class DMDocument extends Object {
 				lLDDSchemaFileDefn.isLDD = true;
 				lLDDSchemaFileDefn.labelVersionId = "1.0";
 				LDDSchemaFileSortArr.add(lLDDSchemaFileDefn);
-				masterLDDSchemaFileDefn = lLDDSchemaFileDefn;
+				masterLDDSchemaFileDefn = lLDDSchemaFileDefn;  // the last Ingest_LDD named is the master.
 //				System.out.println("debug getCommandArgs - lSchemaFileDefn.sourceFileName:" + lLDDSchemaFileDefn.sourceFileName);
 			}	
 		}
@@ -656,15 +656,15 @@ public class DMDocument extends Object {
 			System.exit(1);
 		}
 		
-		if (LDDToolFlag) {
-			if (LDDToolMissionGovernanceFlag) {
-				governanceLevel = "Mission";
-				LDDToolSingletonClassTitle = "Mission_Area";
-			} else {
-				governanceLevel = "Discipline";
-				LDDToolSingletonClassTitle = "Discipline_Area";
-			}
-		}
+//		if (LDDToolFlag) {
+//			if (LDDToolMissionGovernanceFlag) {
+//				governanceLevel = "Mission";
+//				LDDToolSingletonClassTitle = "Mission_Area";
+//			} else {
+//				governanceLevel = "Discipline";
+//				LDDToolSingletonClassTitle = "Discipline_Area";
+//			}
+//		}
 	}
 
 	static private void cleanupLDDInputFileName (SchemaFileDefn lSchemaFileDefn) {
@@ -830,11 +830,7 @@ public class DMDocument extends Object {
         	    String value = prop.getProperty(isMasterKey);
         		if (value != null){
         			if (value.equals("true")) {
-          			   lSchemaFileDefn.isMaster = true;
-         			   lSchemaFileDefn.isLDD = false;
-        			} else {
-        				lSchemaFileDefn.isMaster = false;
-        				lSchemaFileDefn.isLDD = true;
+        				lSchemaFileDefn.setDictionaryType ("Common");
         			}
         		} else{
         			System.out.println("Missing schema config item: "+ isMasterKey);
@@ -862,20 +858,16 @@ public class DMDocument extends Object {
         	    value = prop.getProperty(isDisciplineKey);
         		if (value != null){
         			if (value.equals("true")) {
-        			   lSchemaFileDefn.isDiscipline = true;
-        			   lSchemaFileDefn.governanceLevel = "Discipline";
-        			} else
-        			   lSchemaFileDefn.isDiscipline = false;
+        				lSchemaFileDefn.setDictionaryType ("Discipline");
+        			}
         		} 
         		
         		String isMissionKey = SCHEMA_LITERAL+nameSpaceId + ".isMission";
         		value = prop.getProperty(isMissionKey);
             	if (value != null){
             		if (value.equals("true")) {
-            			   lSchemaFileDefn.isMission = true;
-            			   lSchemaFileDefn.governanceLevel = "Mission";
-            		} else
-            		       lSchemaFileDefn.isMission = false;
+        				lSchemaFileDefn.setDictionaryType ("Mission");
+            		}
         	    }    	
         		
           		String stewardArrKey = SCHEMA_LITERAL+nameSpaceId + ".stewardArr";

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -119,7 +119,8 @@ public abstract class DOMInfoModel extends Object {
 	static TreeMap <String, DOMIndexDefn> cdDOMAttrMap = new TreeMap <String, DOMIndexDefn>();
 	static TreeMap <String, DOMIndexDefn> decDOMAttrMap = new TreeMap <String, DOMIndexDefn>();
 	
-	static DOMClass LDDToolSingletonDOMClass; // Class for LDD singleton attributes (Discipline or Mission)
+//	static String LDDToolSingletonClassTitle = "USER";
+	static DOMClass LDDToolSingletonDOMClass = null; // Class for LDD singleton attributes (Discipline or Mission)
 	
 	// global science discipline facet map 
 	static TreeMap <String, SFDisciplineFacetDefn> sfDisciplineFacetDefnMap = new TreeMap <String, SFDisciplineFacetDefn> ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -368,7 +368,7 @@ public class GetDOMModel extends Object {
 		//       *** TBD ***
 		if (DMDocument.LDDToolFlag) {
 			String lClassIdentifier;
-			if (DMDocument.LDDToolMissionGovernanceFlag) {
+			if (DMDocument.masterLDDSchemaFileDefn.isMission) {
 				lClassIdentifier = DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, "Mission_Area");
 			} else {
 				lClassIdentifier = DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, "Discipline_Area");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -144,7 +144,7 @@ public class SchemaFileDefn {
 		modelShortName = "TBD_modelShortName";
 		regAuthId =  "TBD_regAuthId";
 		
-		governanceLevel = DMDocument.governanceLevel;
+		governanceLevel = "TBD_governanceLevel";
 		isMaster = false;
 		isLDD = false;
 		isDiscipline = false;
@@ -211,7 +211,30 @@ public class SchemaFileDefn {
 		regAuthId = lSchemaFileDefn.regAuthId;
 		return;
 	}
-
+	
+	public void setDictionaryType (String lDictionaryType) {
+		if (lDictionaryType.compareTo("Common") == 0) {
+			governanceLevel = "Common";
+			isMaster = true;
+			isLDD = false;
+			isDiscipline = false;
+			isMission = false;
+		} else if (lDictionaryType.compareTo("Discipline") == 0) {
+			governanceLevel = "Discipline";
+			isMaster = false;
+			isLDD = true;
+			isDiscipline = true;
+			isMission = false;
+		} else if (lDictionaryType.compareTo("Mission") == 0) {
+			governanceLevel = "Mission";
+			isMaster = false;
+			isLDD = true;
+			isDiscipline = false;
+			isMission = true;
+		}
+		return;
+	}
+	
 	//	set the various version identifiers
 	public void setVersionIds () {
 		// get a cleaned up version id

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -82,7 +82,7 @@ class WriteDOMSchematron extends Object {
 								&& lSchemaFileDefn.stewardArr.contains(lRule.classSteward)))) continue;
 			} else if (lSchemaFileDefn.isLDD) {
 				// write an LDD schemtron
-				if (! (lRule.isMissionOnly && DMDocument.LDDToolMissionGovernanceFlag)) continue;
+				if (! (lRule.isMissionOnly && lSchemaFileDefn.isMission)) continue;
 				if (!((lSchemaFileDefn.nameSpaceIdNC.compareTo(lRule.classNameSpaceNC) == 0
 						&& lSchemaFileDefn.stewardArr.contains(lRule.classSteward))
 						|| (lRule.classTitle.compareTo(DMDocument.LDDToolSingletonClassTitle) == 0 ))) continue;
@@ -213,7 +213,7 @@ class WriteDOMSchematron extends Object {
 			prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\" prefix=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "\"/>");
 			// namespaces required: ldd
 			String governanceDirectory = "";
-			if (DMDocument.LDDToolMissionGovernanceFlag) governanceDirectory = DMDocument.governanceLevel.toLowerCase() +  "/";
+			if (lSchemaFileDefn.isMission) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
 			prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\" prefix=\"" + lSchemaFileDefn.nameSpaceIdNC + "\"/>");
 			// namespaces required: all other LDD discipline levels referenced; no mission level allowed
 			for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -54,6 +54,8 @@ class XML4LabelSchemaDOM extends Object {
 
 //	write the XML Label
 	public void writeXMLSchemaFiles (SchemaFileDefn lSchemaFileDefn, ArrayList <DOMClass> lInputClassArr) throws java.io.IOException {
+		
+		if (DMDocument.debugFlag) System.out.println("\ndebug writeXMLSchemaFiles - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
 
 		// get the classes
 		classHierMap = getPDS4ClassesForSchema (lSchemaFileDefn, lInputClassArr);
@@ -131,9 +133,11 @@ class XML4LabelSchemaDOM extends Object {
 		}
 				
 //		Write the classes
+		if (DMDocument.debugFlag) System.out.println("debug writeXMLSchemaFiles - Write Classes - classHierMap.size():" + classHierMap.size());
 		ArrayList <DOMClass> lClassArr = new ArrayList <DOMClass> (classHierMap.values());
 		for (Iterator <DOMClass> i = lClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
+//			if (DMDocument.debugFlag) System.out.println("debug writeXMLSchemaFiles - Write Class - lClass.identifier:" + lClass.identifier);
 			
 			// skip the subclasses of Science_Facets
 			if (lClass.title.compareTo("Discipline_Facets") == 0) continue;
@@ -253,6 +257,9 @@ class XML4LabelSchemaDOM extends Object {
 		}
 		prXML.println("  <" + pNS + "schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"");
 		
+		if (DMDocument.debugFlag) System.out.println("debug writeXMLSchemaFileHeader - lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
+		if (DMDocument.debugFlag) System.out.println("debug writeXMLSchemaFileHeader - DMDocument.masterNameSpaceIdNCLC:" + DMDocument.masterNameSpaceIdNCLC);
+		
 		// write namespace statements
 		if (lSchemaFileDefn.nameSpaceIdNC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
 			// namespaces required: pds - latest version
@@ -261,7 +268,7 @@ class XML4LabelSchemaDOM extends Object {
 		} else {
 			// namespaces required: ldd - latest version
 			String governanceDirectory = "";
-			if (DMDocument.LDDToolMissionGovernanceFlag) governanceDirectory = DMDocument.governanceLevel.toLowerCase() +  "/";
+			if (lSchemaFileDefn.isMission) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
 			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
 			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
 


### PR DESCRIPTION
Deprecate -M command line option (indicates Mission LDD) for LDDTool. Replaced by the attribute dictionary_type in Ingest_LDD. The dictionary_type attribute provides the name of a dictionary category.

Resolves #144
Refs CCB-274