### PR TITLE
Change the error message reported for "nillable" attribute error.

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1679,7 +1679,7 @@ public class LDDDOMParser extends Object
 					}
 				}
 				if (! foundFlag) {
-					lddErrorMsg.add("   ERROR    Attribute: <" + lDOMAttr.title + "> - The attribute is 'nilable' however it is not required in at least one class.");
+					lddErrorMsg.add("   ERROR    Attribute: <" + lDOMAttr.title + "> - A 'nilable' attribute must be a required attribute in at least one class.");
 				}
 			}
 		}


### PR DESCRIPTION
Change the error message reported when an attribute that is defined as "nillable" is not a required attribute of at least one class.

Resolves #146
Refs CCB-204