### PR TITLE
BugFix - Add <DD_Associate_External_Class> to <DD_Class> definition

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Mar 11 20:25:46 PDT 2020
+; Thu Mar 12 15:01:42 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Mar 11 20:25:46 PDT 2020
+; Thu Mar 12 15:01:42 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -9583,7 +9583,7 @@
 	(multislot dd_association
 ;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
 		(type INSTANCE)
-;+		(allowed-classes DD_Association DD_Association_External XSChoice%23)
+;+		(allowed-classes DD_Association DD_Association_External DD_Associate_External_Class XSChoice%23)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Wed Mar 11 20:38:33 PDT 2020
+; Thu Mar 12 15:06:27 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -51714,6 +51714,15 @@
 	(administrationRecord [DD_1.14.0.0])
 	(classOrder "1080")
 	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.data_object.Conceptual_Object")
+	(registeredBy [RA_0001_NASA_PDS_1])
+	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
+	(versionIdentifier "1.14"))
+
+([PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Associate_External_Class] of  Property
+
+	(administrationRecord [DD_1.14.0.0])
+	(classOrder "1090")
+	(dataIdentifier "PR.0001_NASA_PDS_1.pds.DD_Class.pds.dd_association.DD_Associate_External_Class")
 	(registeredBy [RA_0001_NASA_PDS_1])
 	(registrationAuthorityIdentifier [0001_NASA_PDS_1])
 	(versionIdentifier "1.14"))


### PR DESCRIPTION
The Common (pds) schema is missing <DD_Associate_External_Class> in the <DD_Class> definition.

Resolves #130
Refs CCB-256